### PR TITLE
use square brackets instead of .get() for relation data

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -133,9 +133,9 @@ class GatewayAPICharm(CharmBase):
 
         event.set_results(
             {
-                f"certificate-{hostname}": tls_rel_data.get(f"certificate-{hostname}"),
-                f"ca-{hostname}": tls_rel_data.get(f"ca-{hostname}"),
-                f"chain-{hostname}": tls_rel_data.get(f"chain-{hostname}"),
+                f"certificate-{hostname}": tls_rel_data[f"certificate-{hostname}"],
+                f"ca-{hostname}": tls_rel_data[f"ca-{hostname}"],
+                f"chain-{hostname}": tls_rel_data[f"chain-{hostname}"],
             }
         )
 


### PR DESCRIPTION
Discussed internally, since we check for the existence of the keys before returning the results, we use `[]` to access the value since we'll have an exception flow to the charm if somehow it fails. It's  a better approach than using `.get()` to return invalid data.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
