### PR TITLE
ISD-1900 add src-docs to minimal charm implementation

### DIFF
--- a/src-docs/charm.py.md
+++ b/src-docs/charm.py.md
@@ -1,0 +1,90 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/charm.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `charm.py`
+gateway-api-integrator charm file. 
+
+**Global Variables**
+---------------
+- **TLS_CERT**
+
+
+---
+
+## <kbd>class</kbd> `GatewayAPICharm`
+The main charm class for the gateway-api-integrator charm. 
+
+<a href="../src/charm.py#L41"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(*args) → None
+```
+
+Init method for the class. 
+
+
+
+**Args:**
+ 
+ - <b>`args`</b>:  Variable list of positional arguments passed to the parent constructor. 
+
+
+---
+
+#### <kbd>property</kbd> app
+
+Application that this unit is part of. 
+
+---
+
+#### <kbd>property</kbd> charm_dir
+
+Root directory of the charm as it is running. 
+
+---
+
+#### <kbd>property</kbd> config
+
+A mapping containing the charm's config and current values. 
+
+---
+
+#### <kbd>property</kbd> meta
+
+Metadata of this charm. 
+
+---
+
+#### <kbd>property</kbd> model
+
+Shortcut for more simple access the model. 
+
+---
+
+#### <kbd>property</kbd> unit
+
+Unit that this execution is responsible for. 
+
+
+
+---
+
+<a href="../src/charm.py#L80"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_hostname`
+
+```python
+get_hostname() → str
+```
+
+Get a list containing all ingress hostnames. 
+
+
+
+**Returns:**
+  A list containing service and additional hostnames 
+
+

--- a/src-docs/exceptions.py.md
+++ b/src-docs/exceptions.py.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/exceptions.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `exceptions.py`
+Exceptions used by the nginx-ingress-integrator charm. 
+
+
+
+---
+
+## <kbd>class</kbd> `InvalidIngressError`
+Custom error that indicates invalid ingress definition. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  error message. 
+
+<a href="../src/exceptions.py#L14"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(msg: str)
+```
+
+Construct the InvalidIngressError object. 
+
+
+
+**Args:**
+ 
+ - <b>`msg`</b>:  error message. 
+
+
+
+
+

--- a/src-docs/gateway_definition.py.md
+++ b/src-docs/gateway_definition.py.md
@@ -1,0 +1,36 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/gateway_definition.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `gateway_definition.py`
+gateway-api-integrator gateway definition. 
+
+
+---
+
+<a href="../src/gateway_definition.py#L11"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+## <kbd>function</kbd> `get_config`
+
+```python
+get_config(
+    charm: CharmBase,
+    field: str
+) → Union[str, float, int, bool, NoneType]
+```
+
+Get data from charm config. 
+
+
+
+**Args:**
+ 
+ - <b>`charm`</b>:  The charm. 
+ - <b>`field`</b>:  Config field. 
+
+
+
+**Returns:**
+ The field's content. 
+
+

--- a/src-docs/tls_relation.py.md
+++ b/src-docs/tls_relation.py.md
@@ -1,0 +1,293 @@
+<!-- markdownlint-disable -->
+
+<a href="../src/tls_relation.py#L0"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+# <kbd>module</kbd> `tls_relation.py`
+Gateway API TLS relation business logic. 
+
+**Global Variables**
+---------------
+- **TLS_CERT**
+
+
+---
+
+## <kbd>class</kbd> `TLSRelationService`
+TLS Relation service class. 
+
+<a href="../src/tls_relation.py#L31"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `__init__`
+
+```python
+__init__(model: Model) → None
+```
+
+Init method for the class. 
+
+
+
+**Args:**
+ 
+ - <b>`model`</b>:  The charm model used to get the relations and secrets. 
+
+
+
+
+---
+
+<a href="../src/tls_relation.py#L242"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `certificate_expiring`
+
+```python
+certificate_expiring(
+    event: Union[CertificateExpiringEvent, CertificateInvalidatedEvent],
+    certificates: TLSCertificatesRequiresV3
+) → None
+```
+
+Handle the TLS Certificate expiring event. 
+
+
+
+**Args:**
+ 
+ - <b>`event`</b>:  The event that fires this method. 
+ - <b>`certificates`</b>:  The certificate requirer library instance. 
+
+---
+
+<a href="../src/tls_relation.py#L218"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `certificate_relation_available`
+
+```python
+certificate_relation_available(event: CertificateAvailableEvent) → None
+```
+
+Handle the TLS Certificate available event. 
+
+
+
+**Args:**
+ 
+ - <b>`event`</b>:  The event that fires this method. 
+
+---
+
+<a href="../src/tls_relation.py#L191"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `certificate_relation_created`
+
+```python
+certificate_relation_created(hostname: str) → None
+```
+
+Handle the TLS Certificate created event. 
+
+
+
+**Args:**
+ 
+ - <b>`hostname`</b>:  Certificate's hostname. 
+
+---
+
+<a href="../src/tls_relation.py#L166"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `certificate_relation_joined`
+
+```python
+certificate_relation_joined(
+    hostname: str,
+    certificates: TLSCertificatesRequiresV3
+) → None
+```
+
+Handle the TLS Certificate joined event. 
+
+
+
+**Args:**
+ 
+ - <b>`hostname`</b>:  Certificate's hostname. 
+ - <b>`certificates`</b>:  The certificate requirer library instance. 
+
+---
+
+<a href="../src/tls_relation.py#L54"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `generate_password`
+
+```python
+generate_password() → str
+```
+
+Generate a random 12 character password. 
+
+
+
+**Returns:**
+ 
+ - <b>`str`</b>:  Private key string. 
+
+---
+
+<a href="../src/tls_relation.py#L272"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_decrypted_keys`
+
+```python
+get_decrypted_keys() → Dict[str, str]
+```
+
+Return the list of decrypted private keys. 
+
+
+
+**Returns:**
+  A dictionary indexed by domain, containing the decrypted private keys. 
+
+---
+
+<a href="../src/tls_relation.py#L139"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_hostname_from_cert`
+
+```python
+get_hostname_from_cert(certificate: str) → str
+```
+
+Get the hostname from a certificate subject name. 
+
+
+
+**Args:**
+ 
+ - <b>`certificate`</b>:  The certificate in PEM format. 
+
+
+
+**Returns:**
+ The hostname the certificate is issue to. 
+
+---
+
+<a href="../src/tls_relation.py#L120"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_relation_data_field`
+
+```python
+get_relation_data_field(relation_field: str, tls_relation: Relation) → str
+```
+
+Get an item from the app relation databag. 
+
+
+
+**Args:**
+ 
+ - <b>`relation_field`</b>:  item to get 
+ - <b>`tls_relation`</b>:  TLS certificates relation 
+
+
+
+**Returns:**
+ The value from the field. 
+
+
+
+**Raises:**
+ 
+ - <b>`KeyError`</b>:  if the field is not found in the relation databag. 
+
+---
+
+<a href="../src/tls_relation.py#L156"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `get_tls_relation`
+
+```python
+get_tls_relation() → Optional[Relation]
+```
+
+Get the TLS certificates relation. 
+
+
+
+**Returns:**
+  The TLS certificates relation of the charm. 
+
+---
+
+<a href="../src/tls_relation.py#L106"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `pop_relation_data_fields`
+
+```python
+pop_relation_data_fields(relation_fields: list, tls_relation: Relation) → None
+```
+
+Pop a list of items from the app relation databag. 
+
+
+
+**Args:**
+ 
+ - <b>`relation_fields`</b>:  items to pop 
+ - <b>`tls_relation`</b>:  TLS certificates relation 
+
+---
+
+<a href="../src/tls_relation.py#L63"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `update_cert_on_service_hostname_change`
+
+```python
+update_cert_on_service_hostname_change(
+    hostnames: List[str],
+    tls_certificates_relation: Optional[Relation],
+    namespace: str
+) → List[str]
+```
+
+Handle TLS certificate updates when the charm config changes. 
+
+
+
+**Args:**
+ 
+ - <b>`hostnames`</b>:  Ingress service hostname list. 
+ - <b>`tls_certificates_relation`</b>:  TLS Certificates relation. 
+ - <b>`namespace`</b>:  Kubernetes namespace. 
+
+
+
+**Returns:**
+ 
+ - <b>`bool`</b>:  If the TLS certificate needs to be updated. 
+
+---
+
+<a href="../src/tls_relation.py#L96"><img align="right" style="float:right;" src="https://img.shields.io/badge/-source-cccccc?style=flat-square"></a>
+
+### <kbd>function</kbd> `update_relation_data_fields`
+
+```python
+update_relation_data_fields(
+    relation_fields: dict,
+    tls_relation: Relation
+) → None
+```
+
+Update a dict of items from the app relation databag. 
+
+
+
+**Args:**
+ 
+ - <b>`relation_fields`</b>:  items to update 
+ - <b>`tls_relation`</b>:  TLS certificates relation 
+
+


### PR DESCRIPTION
Add src-docs 

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
