### PR TITLE
Update charmcraft to only run on noble

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -13,3 +13,4 @@ jobs:
       self-hosted-runner: true
       self-hosted-runner-label: "large"
       juju-channel: 3.3/stable
+      charmcraft-channel: latest/edge

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,3 +10,4 @@ jobs:
     with:
       self-hosted-runner: true
       self-hosted-runner-image: "noble"
+      charmcraft-channel: latest/edge

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -8,9 +8,6 @@ bases:
       architectures: [amd64]
     run-on:
     - name: ubuntu
-      channel: "22.04"
-      architectures: [amd64]
-    - name: ubuntu
       channel: "24.04"
       architectures: [amd64]
 parts:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,15 +1,14 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 type: charm
-bases:
-  - build-on:
-    - name: ubuntu
-      channel: "22.04"
-      architectures: [amd64]
-    run-on:
-    - name: ubuntu
-      channel: "24.04"
-      architectures: [amd64]
+base: ubuntu@24.04
+build-base: ubuntu@24.04
+
+platforms:
+  amd64:
+    build-on: amd64
+    build-for: amd64
+
 parts:
   charm:
     build-packages:


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Update the charm to only run on noble.

### Rationale

Since this is a new charm, it's easier for us if we only support the latest LTS now https://bugs.launchpad.net/juju/+bug/2069952 is resolved.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
