### PR TITLE
remove build-on and run-on when arch is amd64

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   integration-tests:
-    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@add_support_for_canonical_k8s
+    uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@add_support_for_canonical_k8s_w_workaround
     secrets: inherit
     with:
       provider: k8s

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,8 +6,6 @@ build-base: ubuntu@24.04
 
 platforms:
   amd64:
-    build-on: amd64
-    build-for: amd64
 
 parts:
   charm:


### PR DESCRIPTION
Even though defining `build-on` and `run-on` arch still works when packing charm, `charmcraft expand-extensions` will give the following error: 

```
  /snap/bin/charmcraft expand-extensions
  charmcraft internal error: RepresenterError('cannot represent an object', <CharmArch.amd64: 'amd64'>)
  Full execution log: '/home/runner/.local/state/charmcraft/log/charmcraft-20240628-130714.923693.log'
```

While the error is confusing, it basically said that CharmArch.amd64 must be empty. This PR removes the 2 keys under `platforms.amd64`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
