### PR TITLE
ISD-2100 Refactor tls_relation module and charm state logic

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -16,27 +16,24 @@ from charms.tls_certificates_interface.v3.tls_certificates import (
 )
 from lightkube import Client, KubeConfig
 from lightkube.core.exceptions import ConfigError
-from ops.charm import ActionEvent, CharmBase, RelationCreatedEvent, RelationJoinedEvent
-from ops.jujuversion import JujuVersion
-from ops.main import main
-from ops.model import (
-    ActiveStatus,
-    BlockedStatus,
-    MaintenanceStatus,
-    Relation,
-    SecretNotFoundError,
-    WaitingStatus,
+from ops.charm import (
+    ActionEvent,
+    CharmBase,
+    RelationBrokenEvent,
+    RelationCreatedEvent,
+    RelationJoinedEvent,
 )
+from ops.main import main
+from ops.model import ActiveStatus, MaintenanceStatus, SecretNotFoundError, WaitingStatus
 
 from resource_manager.gateway import GatewayResourceDefinition, GatewayResourceManager
-from resource_manager.permission import InsufficientPermissionError
 from resource_manager.resource_manager import InvalidResourceError
 from resource_manager.secret import SecretResourceDefinition, TLSSecretResourceManager
-from state.config import CharmConfig, InvalidCharmConfigError
+from state.config import CharmConfig
 from state.gateway import GatewayResourceInformation
-from state.tls import TLSInformation, TlsIntegrationMissingError
+from state.tls import TLSInformation
 from state.validation import validate_config_and_integration
-from tls_relation import TLSRelationService
+from tls_relation import TLSRelationService, get_hostname_from_cert
 
 TLS_CERT = "certificates"
 logger = logging.getLogger(__name__)
@@ -86,7 +83,7 @@ class GatewayAPICharm(CharmBase):
         super().__init__(*args)
 
         self.certificates = TLSCertificatesRequiresV3(self, TLS_CERT)
-        self._tls = TLSRelationService(self.model)
+        self._tls = TLSRelationService(self.certificates)
 
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.start, self._on_start)
@@ -131,7 +128,7 @@ class GatewayAPICharm(CharmBase):
         client = _get_client(field_manager=self.app.name, namespace=self.model.name)
         config = CharmConfig.from_charm(self, client)
         gateway_resource_information = GatewayResourceInformation.from_charm(self)
-        tls_information = TLSInformation.from_charm(self)
+        tls_information = TLSInformation.from_charm(self, self.certificates)
 
         gateway_resource_manager = GatewayResourceManager(
             labels=self._labels,
@@ -141,7 +138,9 @@ class GatewayAPICharm(CharmBase):
 
         try:
             secret = secret_resource_manager.define_resource(
-                SecretResourceDefinition(gateway_resource_information, config, tls_information)
+                SecretResourceDefinition.from_tls_information(
+                    tls_information, config.external_hostname
+                )
             )
             gateway = gateway_resource_manager.define_resource(
                 GatewayResourceDefinition(gateway_resource_information, config, tls_information)
@@ -149,9 +148,6 @@ class GatewayAPICharm(CharmBase):
         except InvalidResourceError as exc:
             logger.exception("Error creating resource")
             raise RuntimeError("Error creating resource.") from exc
-        except InsufficientPermissionError as exc:
-            self.unit.status = BlockedStatus(str(exc))
-            return
 
         self.unit.status = WaitingStatus("Waiting for gateway address")
         if gateway_address := gateway_resource_manager.gateway_address(gateway.metadata.name):
@@ -177,116 +173,55 @@ class GatewayAPICharm(CharmBase):
             event: Juju event
         """
         hostname = event.params["hostname"]
-        tls_information = TLSInformation.from_charm(self)
+        TLSInformation.from_charm(self, self.certificates)
 
-        tls_rel_data = tls_information.tls_requirer_integration.data[self.app]
-        if any(
-            not tls_rel_data.get(key)
-            for key in [f"certificate-{hostname}", f"ca-{hostname}", f"chain-{hostname}"]
-        ):
-            event.fail("Missing or incomplete certificate data")
-            return
+        for cert in self.certificates.get_provider_certificates():
+            if get_hostname_from_cert(cert.certificate) == hostname:
+                event.set_results(
+                    {
+                        "certificate": cert.certificate,
+                        "ca": cert.ca,
+                        "chain": cert.chain_as_pem(),
+                    }
+                )
+                return
 
-        event.set_results(
-            {
-                f"certificate-{hostname}": tls_rel_data[f"certificate-{hostname}"],
-                f"ca-{hostname}": tls_rel_data[f"ca-{hostname}"],
-                f"chain-{hostname}": tls_rel_data[f"chain-{hostname}"],
-            }
-        )
+        event.fail(f"Missing or incomplete certificate data for {hostname}")
 
     @validate_config_and_integration(defer=True)
     def _on_certificates_relation_created(self, _: RelationCreatedEvent) -> None:
         """Handle the TLS Certificate relation created event."""
-        tls_information = TLSInformation.from_charm(self)
-
+        TLSInformation.from_charm(self, self.certificates)
         client = _get_client(field_manager=self.app.name, namespace=self.model.name)
         config = CharmConfig.from_charm(self, client)
-
-        self._tls.certificate_relation_created(
-            config.external_hostname, tls_information.tls_requirer_integration
-        )
+        self._tls.certificate_relation_created(config.external_hostname)
 
     @validate_config_and_integration(defer=True)
     def _on_certificates_relation_joined(self, _: RelationJoinedEvent) -> None:
         """Handle the TLS Certificate relation joined event."""
-        tls_information = TLSInformation.from_charm(self)
-
+        TLSInformation.from_charm(self, self.certificates)
         client = _get_client(field_manager=self.app.name, namespace=self.model.name)
         config = CharmConfig.from_charm(self, client)
+        self._tls.certificate_relation_joined(config.external_hostname)
 
-        self._tls.certificate_relation_joined(
-            config.external_hostname,
-            self.certificates,
-            tls_information.tls_requirer_integration,
-        )
-
-    def _on_certificates_relation_broken(self, _: typing.Any) -> None:
+    def _on_certificates_relation_broken(self, _: RelationBrokenEvent) -> None:
         """Handle the TLS Certificate relation broken event."""
         self._reconcile()
 
-    @validate_config_and_integration(defer=True)
-    def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
-        """Handle the TLS Certificate available event.
-
-        Args:
-            event: The event that fires this method.
-        """
-        tls_information = TLSInformation.from_charm(self)
-
-        self._tls.certificate_relation_available(event, tls_information.tls_requirer_integration)
-        logger.info("TLS configured, creating kubernetes resources.")
+    def _on_certificate_available(self, _: CertificateAvailableEvent) -> None:
+        """Handle the TLS Certificate available event."""
+        logger.info("TLS certificate available, creating resources.")
         self._reconcile()
 
     @validate_config_and_integration(defer=True)
-    def _on_certificate_expiring(
-        self,
-        event: typing.Union[CertificateExpiringEvent, CertificateInvalidatedEvent],
-    ) -> None:
+    def _on_certificate_expiring(self, event: CertificateExpiringEvent) -> None:
         """Handle the TLS Certificate expiring event.
 
         Args:
             event: The event that fires this method.
         """
-        tls_information = TLSInformation.from_charm(self)
-        self._tls.certificate_expiring(
-            event, self.certificates, tls_information.tls_requirer_integration
-        )
-
-    # This method is too complex but hard to simplify.
-    def _certificate_revoked(
-        self, revoke_list: typing.List[str], tls_requirer_integration: Relation
-    ) -> None:  # noqa: C901
-        """Handle TLS Certificate revocation.
-
-        Args:
-            revoke_list: TLS Certificates list to revoke
-            tls_requirer_integration: The TLS certificate integration.
-        """
-        for hostname in revoke_list:
-            old_csr = self._tls.get_relation_data_field(
-                f"csr-{hostname}",
-                tls_requirer_integration,  # type: ignore[arg-type]
-            )
-            if not old_csr:
-                continue
-            if JujuVersion.from_environ().has_secrets:
-                try:
-                    secret = self.model.get_secret(label=f"private-key-{hostname}")
-                    secret.remove_all_revisions()
-                except SecretNotFoundError:
-                    logger.warning("Juju secret for %s already does not exist", hostname)
-                    continue
-            try:
-                self._tls.pop_relation_data_fields(
-                    [f"key-{hostname}", f"password-{hostname}"],
-                    tls_requirer_integration,  # type: ignore[arg-type]
-                )
-            except KeyError:
-                logger.warning("Relation data for %s already does not exist", hostname)
-            self.certificates.request_certificate_revocation(
-                certificate_signing_request=old_csr.encode()
-            )
+        TLSInformation.from_charm(self, self.certificates)
+        self._tls.certificate_expiring(event)
 
     @validate_config_and_integration(defer=True)
     def _on_certificate_invalidated(self, event: CertificateInvalidatedEvent) -> None:
@@ -295,41 +230,26 @@ class GatewayAPICharm(CharmBase):
         Args:
             event: The event that fires this method.
         """
-        try:
-            tls_information = TLSInformation.from_charm(self)
-        except (TlsIntegrationMissingError, InvalidCharmConfigError) as exc:
-            self.unit.status = WaitingStatus("Waiting for certificates relation to be created")
-            logger.error(
-                "(%s) charm is not ready to handle this event, deferring: %s.", event, exc
-            )
-            event.defer()
-            return
-
+        TLSInformation.from_charm(self, self.certificates)
         if event.reason == "revoked":
-            hostname = self._tls.get_hostname_from_cert(event.certificate)
-            self._certificate_revoked([hostname], tls_information.tls_requirer_integration)
+            self._tls.certificate_invalidated(event)
         if event.reason == "expired":
-            self._tls.certificate_expiring(
-                event, self.certificates, tls_information.tls_requirer_integration
-            )
+            self._tls.certificate_expiring(event)
         self.unit.status = MaintenanceStatus("Waiting for new certificate")
 
     @validate_config_and_integration(defer=True)
     def _on_all_certificates_invalidated(self, _: AllCertificatesInvalidatedEvent) -> None:
         """Handle the TLS Certificate relation broken event."""
-        tls_information = TLSInformation.from_charm(self)
-        tls_information.tls_requirer_integration.data[self.app].clear()
-
+        TLSInformation.from_charm(self, self.certificates)
         client = _get_client(field_manager=self.app.name, namespace=self.model.name)
         config = CharmConfig.from_charm(self, client)
+        hostname = config.external_hostname
 
-        if JujuVersion.from_environ().has_secrets:
-            hostname = config.external_hostname
-            try:
-                secret = self.model.get_secret(label=f"private-key-{hostname}")
-                secret.remove_all_revisions()
-            except SecretNotFoundError:
-                logger.warning("Juju secret for %s already does not exist", hostname)
+        try:
+            secret = self.model.get_secret(label=f"private-key-{hostname}")
+            secret.remove_all_revisions()
+        except SecretNotFoundError:
+            logger.warning("Juju secret for %s already does not exist", hostname)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/resource_manager/gateway.py
+++ b/src/resource_manager/gateway.py
@@ -96,7 +96,7 @@ class GatewayResourceManager(ResourceManager[GenericNamespacedResource]):
         """Generate a Gateway resource from a gateway resource definition.
 
         Args:
-            resource_definition: Part of charm state.
+            resource_definition: The data necessary to create the gateway resource.
 
         Returns:
             A dictionary representing the gateway custom resource.

--- a/src/resource_manager/gateway.py
+++ b/src/resource_manager/gateway.py
@@ -92,38 +92,39 @@ class GatewayResourceManager(ResourceManager[GenericNamespacedResource]):
         return ",".join(f"{k}={v}" for k, v in self._labels.items())
 
     @map_k8s_auth_exception
-    def _gen_resource(self, state: ResourceDefinition) -> dict:
+    def _gen_resource(self, resource_definition: ResourceDefinition) -> dict:
         """Generate a Gateway resource from a gateway resource definition.
 
         Args:
-            state: Part of charm state.
+            resource_definition: Part of charm state.
 
         Returns:
             A dictionary representing the gateway custom resource.
         """
-        gateway_state = typing.cast(GatewayResourceDefinition, state)
-        tls_secret_name = (
-            f"{gateway_state.secret_resource_name_prefix}-{gateway_state.external_hostname}"
-        )
+        gateway_resource_definition = typing.cast(GatewayResourceDefinition, resource_definition)
+        prefix = gateway_resource_definition.secret_resource_name_prefix
+        tls_secret_name = f"{prefix}-{gateway_resource_definition.external_hostname}"
         gateway = self._gateway_generic_resource(
             apiVersion="gateway.networking.k8s.io/v1",
             kind="Gateway",
-            metadata=ObjectMeta(name=gateway_state.gateway_name, labels=self._labels),
+            metadata=ObjectMeta(
+                name=gateway_resource_definition.gateway_name, labels=self._labels
+            ),
             spec={
-                "gatewayClassName": gateway_state.gateway_class_name,
+                "gatewayClassName": gateway_resource_definition.gateway_class_name,
                 "listeners": [
                     {
                         "protocol": "HTTP",
                         "port": 80,
-                        "name": f"{gateway_state.gateway_name}-http-listener",
-                        "hostname": gateway_state.external_hostname,
+                        "name": f"{gateway_resource_definition.gateway_name}-http-listener",
+                        "hostname": gateway_resource_definition.external_hostname,
                         "allowedRoutes": {"namespaces": {"from": "All"}},
                     },
                     {
                         "protocol": "HTTPS",
                         "port": 443,
-                        "name": f"{gateway_state.gateway_name}-https-listener",
-                        "hostname": gateway_state.external_hostname,
+                        "name": f"{gateway_resource_definition.gateway_name}-https-listener",
+                        "hostname": gateway_resource_definition.external_hostname,
                         "allowedRoutes": {"namespaces": {"from": "All"}},
                         "tls": {"certificateRefs": [{"kind": "Secret", "name": tls_secret_name}]},
                     },

--- a/src/resource_manager/gateway.py
+++ b/src/resource_manager/gateway.py
@@ -38,7 +38,7 @@ class GatewayResourceDefinition(ResourceDefinition):
         - CharmConfig
         - TLSInformation
 
-    Attrs:
+    Attributes:
         gateway_name: The gateway resource's name
         external_hostname: The configured gateway hostname.
         gateway_class_name: The configured gateway class.

--- a/src/resource_manager/permission.py
+++ b/src/resource_manager/permission.py
@@ -9,10 +9,12 @@ import typing
 
 from lightkube.core.exceptions import ApiError
 
+from state.exception import CharmStateValidationBaseError
+
 logger = logging.getLogger(__name__)
 
 
-class InsufficientPermissionError(Exception):
+class InsufficientPermissionError(CharmStateValidationBaseError):
     """Custom error that indicates insufficient permission to create k8s resources."""
 
 

--- a/src/resource_manager/resource_manager.py
+++ b/src/resource_manager/resource_manager.py
@@ -49,7 +49,7 @@ class ResourceManager(typing.Protocol[AnyResource]):
         """Abstract method to generate a resource from ingress definition.
 
         Args:
-            resource_definition: Part of charm state consisting of one or several components.
+            resource_definition: The data necessary to create the k8s resource.
         """
 
     @abc.abstractmethod

--- a/src/resource_manager/resource_manager.py
+++ b/src/resource_manager/resource_manager.py
@@ -45,11 +45,11 @@ class ResourceManager(typing.Protocol[AnyResource]):
     """Abstract base class for a generic Kubernetes resource controller."""
 
     @abc.abstractmethod
-    def _gen_resource(self, state: ResourceDefinition) -> AnyResource:
+    def _gen_resource(self, resource_definition: ResourceDefinition) -> AnyResource:
         """Abstract method to generate a resource from ingress definition.
 
         Args:
-            state: Part of charm state consisting of one or several components.
+            resource_definition: Part of charm state consisting of one or several components.
         """
 
     @abc.abstractmethod

--- a/src/resource_manager/secret.py
+++ b/src/resource_manager/secret.py
@@ -31,7 +31,7 @@ class CertificateDataNotReadyError(CharmStateValidationBaseError):
 class SecretResourceDefinition(ResourceDefinition):
     """A part of charm state with information required to manage secret resource.
 
-    Attrs:
+    Attributes:
         hostname: The configured gateway hostname.
         secret_resource_name_prefix: Prefix of the secret resource name.
         certificate: TLS certificate.

--- a/src/resource_manager/secret.py
+++ b/src/resource_manager/secret.py
@@ -12,11 +12,9 @@ from lightkube.core.client import LabelSelector
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Secret
 from lightkube.types import PatchType
-from ops.model import Relation
 
 from state.base import ResourceDefinition
-from state.config import CharmConfig
-from state.gateway import GatewayResourceInformation
+from state.exception import CharmStateValidationBaseError
 from state.tls import TLSInformation
 
 from .permission import map_k8s_auth_exception
@@ -25,43 +23,54 @@ from .resource_manager import ResourceManager
 logger = logging.getLogger(__name__)
 
 
+class CertificateDataNotReadyError(CharmStateValidationBaseError):
+    """Exception raised when certificates data is not set on the tls provider."""
+
+
 @dataclasses.dataclass
 class SecretResourceDefinition(ResourceDefinition):
     """A part of charm state with information required to manage secret resource.
 
-    It consistS of 3 components:
-        - SecretResourceInfomation
-        - CharmConfig
-        - TLSInformation
-
     Attrs:
-        external_hostname: The configured gateway hostname.
-        tls_requirer_integration: The integration instance with a TLS provider.
-        tls_certs: A dict of hostname: certificate obtained from the relation.
-        tls_keys: A dict of hostname: private_key stored in juju secrets.
+        hostname: The configured gateway hostname.
         secret_resource_name_prefix: Prefix of the secret resource name.
+        certificate: TLS certificate.
+        private_key: Password-ecrypted private key.
+        password: Private key password.
     """
 
-    external_hostname: str
-    tls_requirer_integration: Relation
-    tls_certs: dict[str, str]
-    tls_keys: dict[str, dict[str, str]]
+    hostname: str
     secret_resource_name_prefix: str
+    certificate: str
+    private_key: str
+    password: str
 
-    def __init__(
-        self,
-        gateway_resource_information: GatewayResourceInformation,
-        charm_config: CharmConfig,
-        tls_information: TLSInformation,
-    ):
-        """Create the state object with state components.
+    @classmethod
+    def from_tls_information(
+        cls, tls_information: TLSInformation, hostname: str
+    ) -> "SecretResourceDefinition":
+        """Get certificate information for a given hostname.
 
         Args:
-            gateway_resource_information: GatewayResourceInformation state component.
-            charm_config: CharmConfig state component.
             tls_information: TLSInformation state component.
+            hostname: The requested hostname.
+
+        Raises:
+            CertificateDataNotReadyError: When the certificate data is not ready.
+
+        Returns:
+            SecretResourceDefinition: Information about the certificate.
         """
-        super().__init__(gateway_resource_information, charm_config, tls_information)
+        if hostname not in tls_information.tls_certs.keys():
+            raise CertificateDataNotReadyError("Certificate data missing or incomplete.")
+
+        return SecretResourceDefinition(
+            hostname=hostname,
+            secret_resource_name_prefix=tls_information.secret_resource_name_prefix,
+            certificate=tls_information.tls_certs[hostname],
+            private_key=tls_information.tls_keys[hostname]["key"],
+            password=tls_information.tls_keys[hostname]["password"],
+        )
 
 
 def _get_decrypted_key(private_key: str, password: str) -> str:
@@ -100,30 +109,28 @@ class TLSSecretResourceManager(ResourceManager[Secret]):
         self._labels = labels
 
     @map_k8s_auth_exception
-    def _gen_resource(self, state: ResourceDefinition) -> Secret:
+    def _gen_resource(self, resource_definition: ResourceDefinition) -> Secret:
         """Generate a Gateway resource from a gateway resource definition.
 
         Args:
-            state: Part of charm state.
+            resource_definition: Part of charm state.
 
         Returns:
             A Secret resource object.
         """
-        secret_state = typing.cast(SecretResourceDefinition, state)
-
-        tls_secret_name = (
-            f"{secret_state.secret_resource_name_prefix}-{secret_state.external_hostname}"
-        )
+        secret_resource_definition = typing.cast(SecretResourceDefinition, resource_definition)
+        prefix = secret_resource_definition.secret_resource_name_prefix
+        tls_secret_name = f"{prefix}-{secret_resource_definition.hostname}"
 
         secret = Secret(
             apiVersion="v1",
             kind="Secret",
             metadata=ObjectMeta(name=tls_secret_name, labels=self._labels),
             stringData={
-                "tls.crt": secret_state.tls_certs[secret_state.external_hostname],
+                "tls.crt": secret_resource_definition.certificate,
                 "tls.key": _get_decrypted_key(
-                    secret_state.tls_keys[secret_state.external_hostname]["key"],
-                    secret_state.tls_keys[secret_state.external_hostname]["password"],
+                    secret_resource_definition.private_key,
+                    secret_resource_definition.password,
                 ),
             },
             type="kubernetes.io/tls",

--- a/src/resource_manager/secret.py
+++ b/src/resource_manager/secret.py
@@ -61,7 +61,7 @@ class SecretResourceDefinition(ResourceDefinition):
         Returns:
             SecretResourceDefinition: Information about the certificate.
         """
-        if hostname not in tls_information.tls_certs.keys():
+        if hostname not in tls_information.tls_certs:
             raise CertificateDataNotReadyError("Certificate data missing or incomplete.")
 
         return SecretResourceDefinition(

--- a/src/state/config.py
+++ b/src/state/config.py
@@ -36,7 +36,7 @@ class GatewayClassUnavailableError(CharmStateValidationBaseError):
 class CharmConfig:
     """A component of charm state that contains the charm's configuration.
 
-    Attrs:
+    Attributes:
         gateway_class_name: The configured gateway class.
         external_hostname: The configured gateway hostname.
     """

--- a/src/state/config.py
+++ b/src/state/config.py
@@ -15,6 +15,8 @@ from pydantic.dataclasses import dataclass
 
 from resource_manager.permission import map_k8s_auth_exception
 
+from .exception import CharmStateValidationBaseError
+
 CUSTOM_RESOURCE_GROUP_NAME = "gateway.networking.k8s.io"
 GATEWAY_CLASS_RESOURCE_NAME = "GatewayClass"
 GATEWAY_CLASS_PLURAL = "gatewayclasses"
@@ -22,11 +24,11 @@ GATEWAY_CLASS_PLURAL = "gatewayclasses"
 logger = logging.getLogger()
 
 
-class InvalidCharmConfigError(Exception):
+class InvalidCharmConfigError(CharmStateValidationBaseError):
     """Exception raised when a charm configuration is found to be invalid."""
 
 
-class GatewayClassUnavailableError(Exception):
+class GatewayClassUnavailableError(CharmStateValidationBaseError):
     """Exception raised when a charm configuration is found to be invalid."""
 
 

--- a/src/state/exception.py
+++ b/src/state/exception.py
@@ -1,0 +1,11 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""gateway-api-integrator charm base exceptions."""
+
+
+class CharmStateValidationBaseError(Exception):
+    """Exception raised when charm state data validation failed."""
+
+
+class ResourceManagementBaseError(Exception):
+    """Exception raised when managing k8s resources."""

--- a/src/state/gateway.py
+++ b/src/state/gateway.py
@@ -12,7 +12,7 @@ import ops
 class GatewayResourceInformation:
     """A component of charm state that contains gateway resource definition.
 
-    Attrs:
+    Attributes:
         gateway_name: The gateway resource's name
     """
 

--- a/src/state/tls.py
+++ b/src/state/tls.py
@@ -23,7 +23,7 @@ class TlsIntegrationMissingError(CharmStateValidationBaseError):
 class TLSInformation:
     """A component of charm state containing information about TLS.
 
-    Attrs:
+    Attributes:
         secret_resource_name_prefix: Prefix of the secret resource name.
         tls_certs: A dict of hostname: certificate obtained from the relation.
         tls_keys: A dict of hostname: private_key stored in juju secrets.

--- a/src/state/tls.py
+++ b/src/state/tls.py
@@ -6,13 +6,21 @@
 import dataclasses
 
 import ops
+from charms.tls_certificates_interface.v3.tls_certificates import TLSCertificatesRequiresV3
 from ops.jujuversion import JujuVersion
-from ops.model import Relation
+
+from tls_relation import get_hostname_from_cert
+
+from .exception import CharmStateValidationBaseError
 
 TLS_CERTIFICATES_INTEGRATION = "certificates"
 
 
-class TlsIntegrationMissingError(Exception):
+class SecretNotSupportedError(CharmStateValidationBaseError):
+    """Exception raised when the juju version does not support secrets."""
+
+
+class TlsIntegrationMissingError(CharmStateValidationBaseError):
     """Exception raised when certificates relation is missing."""
 
 
@@ -22,29 +30,36 @@ class TLSInformation:
 
     Attrs:
         secret_resource_name_prefix: Prefix of the secret resource name.
-        tls_requirer_integration: The integration instance with a TLS provider.
         tls_certs: A dict of hostname: certificate obtained from the relation.
         tls_keys: A dict of hostname: private_key stored in juju secrets.
     """
 
     secret_resource_name_prefix: str
-    tls_requirer_integration: Relation
     tls_certs: dict[str, str]
     tls_keys: dict[str, dict[str, str]]
 
     @classmethod
-    def from_charm(cls, charm: ops.CharmBase) -> "TLSInformation":
+    def from_charm(
+        cls, charm: ops.CharmBase, certificates: TLSCertificatesRequiresV3
+    ) -> "TLSInformation":
         """Get TLS information from a charm instance.
 
         Args:
             charm: The gateway-api-integrator charm.
+            certificates: TLS certificates requirer library.
 
         Raises:
             TlsIntegrationMissingError: When integration is not ready.
+            SecretNotSupportedError: When running with incompatible juju version.
 
         Returns:
             TLSInformation: Information about configured TLS certs.
         """
+        if not JujuVersion.from_environ().has_secrets:
+            raise SecretNotSupportedError(
+                "The charm requires the 'secrets' feature to be supported (juju version >= 3.0.3)."
+            )
+
         tls_requirer_integration = charm.model.get_relation(TLS_CERTIFICATES_INTEGRATION)
         if (
             tls_requirer_integration is None
@@ -56,21 +71,17 @@ class TLSInformation:
         tls_keys = {}
         secret_resource_name_prefix = f"{charm.app.name}-secret"
 
-        for key, value in tls_requirer_integration.data[charm.app].items():
-            if key.startswith("chain-"):
-                hostname = key.split("-", maxsplit=1)[1]
-                tls_certs[hostname] = value
-
-                if JujuVersion.from_environ().has_secrets:
-                    secret = charm.model.get_secret(label=f"private-key-{hostname}")
-                    tls_keys[hostname] = {
-                        "key": secret.get_content()["key"],
-                        "password": secret.get_content()["password"],
-                    }
+        for cert in certificates.get_provider_certificates():
+            hostname = get_hostname_from_cert(cert.certificate)
+            tls_certs[hostname] = cert.certificate
+            secret = charm.model.get_secret(label=f"private-key-{hostname}")
+            tls_keys[hostname] = {
+                "key": secret.get_content()["key"],
+                "password": secret.get_content()["password"],
+            }
 
         return cls(
             secret_resource_name_prefix=secret_resource_name_prefix,
-            tls_requirer_integration=tls_requirer_integration,
             tls_certs=tls_certs,
             tls_keys=tls_keys,
         )

--- a/src/state/validation.py
+++ b/src/state/validation.py
@@ -9,10 +9,7 @@ import typing
 
 import ops
 
-import state
-import state.config
-import state.tls
-from resource_manager.permission import InsufficientPermissionError
+from state.exception import CharmStateValidationBaseError
 
 logger = logging.getLogger(__name__)
 
@@ -58,12 +55,7 @@ def validate_config_and_integration(
             """
             try:
                 return method(instance, *args)
-            except (
-                state.config.InvalidCharmConfigError,
-                state.tls.TlsIntegrationMissingError,
-                state.config.GatewayClassUnavailableError,
-                InsufficientPermissionError,
-            ) as exc:
+            except CharmStateValidationBaseError as exc:
                 if defer:
                     event: ops.EventBase
                     event, *_ = args

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -29,7 +29,7 @@ class InvalidCertificateError(Exception):
 class KeyPair(typing.NamedTuple):
     """Stores a private key and encryption password.
 
-    Attrs:
+    Attributes:
         private_key: The private key
         password: The password used for encryption
     """
@@ -105,10 +105,15 @@ class TLSRelationService:
 
         Args:
             hostname: Certificate's hostname.
+
+        Raises:
+            AssertionError: If this method is called before the certificates integration is ready.
         """
         # At this point, TLSInformation state component should already be initialized
         tls_integration = self.model.get_relation(self.integration_name)
-        assert tls_integration
+        if not tls_integration:
+            raise AssertionError
+
         tls_integration = typing.cast(Relation, tls_integration)
 
         private_key_password = self.generate_password().encode()

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -5,35 +5,54 @@
 """Gateway API TLS relation business logic."""
 import secrets
 import string
-from typing import Dict, Union
+import typing
 
 from charms.tls_certificates_interface.v3.tls_certificates import (
-    CertificateAvailableEvent,
     CertificateExpiringEvent,
     CertificateInvalidatedEvent,
+    ProviderCertificate,
     TLSCertificatesRequiresV3,
     generate_csr,
     generate_private_key,
 )
 from cryptography import x509
 from cryptography.x509.oid import NameOID
-from ops.jujuversion import JujuVersion
-from ops.model import Model, Relation, SecretNotFoundError
+from ops.model import Relation, SecretNotFoundError
 
 TLS_CERT = "certificates"
+
+
+def get_hostname_from_cert(certificate: str) -> str:
+    """Get the hostname from a certificate subject name.
+
+    Args:
+        certificate: The certificate in PEM format.
+
+    Returns:
+        The hostname the certificate is issue to.
+    """
+    decoded_cert = x509.load_pem_x509_certificate(certificate.encode())
+
+    common_name_attribute = decoded_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    if not common_name_attribute:
+        return ""
+
+    return str(common_name_attribute[0].value)
 
 
 class TLSRelationService:
     """TLS Relation service class."""
 
-    def __init__(self, model: Model) -> None:
+    def __init__(self, certificates: TLSCertificatesRequiresV3) -> None:
         """Init method for the class.
 
         Args:
-            model: The charm model used to get the relations and secrets.
+            certificates: The TLS certificates requirer library.
         """
-        self.charm_model = model
-        self.charm_app = model.app
+        self.certificates = certificates
+        self.model = self.certificates.model
+        self.application = self.model.app
+        self.integration_name = self.certificates.relationship_name
 
     def generate_password(self) -> str:
         """Generate a random 12 character password.
@@ -44,161 +63,87 @@ class TLSRelationService:
         chars = string.ascii_letters + string.digits
         return "".join(secrets.choice(chars) for _ in range(12))
 
-    def update_relation_data_fields(self, relation_fields: dict, tls_relation: Relation) -> None:
-        """Update a dict of items from the app relation databag.
-
-        Args:
-            relation_fields: items to update
-            tls_relation: TLS certificates relation
-        """
-        for key, value in relation_fields.items():
-            tls_relation.data[self.charm_app].update({key: value})
-
-    def pop_relation_data_fields(
-        self,
-        relation_fields: list,
-        tls_relation: Relation,
-    ) -> None:
-        """Pop a list of items from the app relation databag.
-
-        Args:
-            relation_fields: items to pop
-            tls_relation: TLS certificates relation
-        """
-        for item in relation_fields:
-            tls_relation.data[self.charm_app].pop(item)
-
-    def get_relation_data_field(self, relation_field: str, tls_relation: Relation) -> str:
-        """Get an item from the app relation databag.
-
-        Args:
-            relation_field: item to get
-            tls_relation: TLS certificates relation
-
-        Returns:
-            The value from the field.
-
-        Raises:
-            KeyError: if the field is not found in the relation databag.
-        """
-        field_value = tls_relation.data[self.charm_app].get(relation_field)
-        if not field_value:
-            raise KeyError(f"{relation_field} field not found in {tls_relation.name}")
-
-        return field_value
-
-    def get_hostname_from_cert(self, certificate: str) -> str:
-        """Get the hostname from a certificate subject name.
-
-        Args:
-            certificate: The certificate in PEM format.
-
-        Returns:
-            The hostname the certificate is issue to.
-        """
-        decoded_cert = x509.load_pem_x509_certificate(certificate.encode())
-
-        common_name_attribute = decoded_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
-        if not common_name_attribute:
-            return ""
-
-        return str(common_name_attribute[0].value)
-
-    # The charm will not have annotations to avoid circular imports.
-    def certificate_relation_joined(  # type: ignore[no-untyped-def]
-        self,
-        hostname: str,
-        certificates: TLSCertificatesRequiresV3,
-        tls_integration: Relation,
-    ) -> None:
+    def certificate_relation_joined(self, hostname: str) -> None:
         """Handle the TLS Certificate joined event.
 
         Args:
             hostname: Certificate's hostname.
-            certificates: The certificate requirer library instance.
-            tls_integration: The tls certificates integration.
         """
-        private_key_dict = self._get_private_key(hostname)
+        private_key, password = self._get_private_key(hostname)
         csr = generate_csr(
-            private_key=private_key_dict["key"].encode(),
-            private_key_password=private_key_dict["password"].encode(),
+            private_key=private_key.encode(),
+            private_key_password=password.encode(),
             subject=hostname,
             sans_dns=[hostname],
         )
-        self.update_relation_data_fields({f"csr-{hostname}": csr.decode()}, tls_integration)
-        certificates.request_certificate_creation(certificate_signing_request=csr)
+        self.certificates.request_certificate_creation(certificate_signing_request=csr)
 
-    def certificate_relation_created(self, hostname: str, tls_integration: Relation) -> None:
+    def certificate_relation_created(self, hostname: str) -> None:
         """Handle the TLS Certificate created event.
 
         Args:
             hostname: Certificate's hostname.
-            tls_integration: The tls certificates integration.
         """
+        # At this point, TLSInformation state component should already be initialized
+        tls_integration = typing.cast(Relation, self.model.get_relation(self.integration_name))
+
         private_key_password = self.generate_password().encode()
         private_key = generate_private_key(password=private_key_password)
         private_key_dict = {
             "password": private_key_password.decode(),
             "key": private_key.decode(),
         }
-        if JujuVersion.from_environ().has_secrets:
-            try:
-                secret = self.charm_model.get_secret(label=f"private-key-{hostname}")
-                secret.set_content(private_key_dict)
-            except SecretNotFoundError:
-                secret = self.charm_app.add_secret(
-                    content=private_key_dict, label=f"private-key-{hostname}"
-                )
-                secret.grant(tls_integration)
+        try:
+            secret = self.model.get_secret(label=f"private-key-{hostname}")
+            secret.set_content(private_key_dict)
+        except SecretNotFoundError:
+            secret = self.application.add_secret(
+                content=private_key_dict, label=f"private-key-{hostname}"
+            )
+            secret.grant(tls_integration)
 
-    def certificate_relation_available(
-        self, event: CertificateAvailableEvent, tls_integration: Relation
-    ) -> None:
-        """Handle the TLS Certificate available event.
-
-        Args:
-            event: The event that fires this method.
-            tls_integration: The tls certificates integration.
-        """
-        hostname = self.get_hostname_from_cert(event.certificate)
-        self.update_relation_data_fields(
-            {
-                f"certificate-{hostname}": event.certificate,
-                f"ca-{hostname}": event.ca,
-                f"chain-{hostname}": str(event.chain_as_pem()),
-            },
-            tls_integration,
-        )
-
-    def certificate_expiring(  # type: ignore[no-untyped-def]
+    def certificate_expiring(
         self,
-        event: Union[CertificateExpiringEvent, CertificateInvalidatedEvent],
-        certificates: TLSCertificatesRequiresV3,
-        tls_integration: Relation,
+        event: CertificateExpiringEvent,
     ) -> None:
         """Handle the TLS Certificate expiring event.
 
         Args:
             event: The event that fires this method.
-            certificates: The certificate requirer library instance.
-            tls_integration: The tls certificates integration.
         """
-        hostname = self.get_hostname_from_cert(event.certificate)
-        old_csr = self.get_relation_data_field(f"csr-{hostname}", tls_integration)
-        private_key_dict = self._get_private_key(hostname)
-        new_csr = generate_csr(
-            private_key=private_key_dict["key"].encode(),
-            private_key_password=private_key_dict["password"].encode(),
-            subject=hostname,
-            sans_dns=[hostname],
-        )
-        certificates.request_certificate_renewal(
-            old_certificate_signing_request=old_csr.encode(),
-            new_certificate_signing_request=new_csr,
-        )
-        self.update_relation_data_fields({f"csr-{hostname}": new_csr.decode()}, tls_integration)
+        if expiring_cert := self._get_cert(event.certificate):
+            hostname = get_hostname_from_cert(expiring_cert.certificate)
+            old_csr = expiring_cert.csr
+            private_key, password = self._get_private_key(hostname)
+            new_csr = generate_csr(
+                private_key=private_key.encode(),
+                private_key_password=password.encode(),
+                subject=hostname,
+                sans_dns=[hostname],
+            )
+            self.certificates.request_certificate_renewal(
+                old_certificate_signing_request=old_csr.encode(),
+                new_certificate_signing_request=new_csr,
+            )
 
-    def _get_private_key(self, hostname: str) -> Dict[str, str]:
+    def certificate_invalidated(
+        self,
+        event: CertificateInvalidatedEvent,
+    ) -> None:
+        """Handle TLS Certificate revocation.
+
+        Args:
+            event: The event that fires this method.
+        """
+        if invalidated_cert := self._get_cert(event.certificate):
+            hostname = get_hostname_from_cert(invalidated_cert.certificate)
+            secret = self.model.get_secret(label=f"private-key-{hostname}")
+            secret.remove_all_revisions()
+            self.certificates.request_certificate_revocation(
+                certificate_signing_request=invalidated_cert.csr.encode()
+            )
+
+    def _get_private_key(self, hostname: str) -> tuple[str, str]:
         """Return the private key and its password from either juju secrets or the relation data.
 
         Args:
@@ -207,9 +152,20 @@ class TLSRelationService:
         Returns:
             The encrypted private key.
         """
-        private_key_dict = {}
-        if JujuVersion.from_environ().has_secrets:
-            secret = self.charm_model.get_secret(label=f"private-key-{hostname}")
-            private_key_dict["key"] = secret.get_content()["key"]
-            private_key_dict["password"] = secret.get_content()["password"]
-        return private_key_dict
+        secret = self.model.get_secret(label=f"private-key-{hostname}")
+        private_key = secret.get_content()["key"]
+        password = secret.get_content()["password"]
+        return (private_key, password)
+
+    def _get_cert(self, certificate: str) -> typing.Optional[ProviderCertificate]:
+        """Get a cert from the provider's integration data that matches 'certificate'.
+
+        Args:
+            certificate: the certificate to match with provider certificates
+
+        Returns:
+            typing.Optional[ProviderCertificate]: ProviderCertificate if exists, else None.
+        """
+        provider_certificates = self.certificates.get_provider_certificates()
+        matching_certs = [cert for cert in provider_certificates if cert == certificate]
+        return matching_certs[0] if matching_certs else None

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -22,6 +22,10 @@ from ops.model import Model, Relation, SecretNotFoundError
 TLS_CERT = "certificates"
 
 
+class InvalidCertificateError(Exception):
+    """Exception raised when certificates is invalid."""
+
+
 class KeyPair(typing.NamedTuple):
     """Stores a private key and encryption password.
 
@@ -42,12 +46,17 @@ def get_hostname_from_cert(certificate: str) -> str:
 
     Returns:
         The hostname the certificate is issue to.
+
+    Raises:
+        InvalidCertificateError: When hostname cannot be parsed from the given certificate.
     """
     decoded_cert = x509.load_pem_x509_certificate(certificate.encode())
 
     common_name_attribute = decoded_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
     if not common_name_attribute:
-        return ""
+        raise InvalidCertificateError(
+            f"Cannot parse hostname from x509 certificate: {certificate}"
+        )
 
     return str(common_name_attribute[0].value)
 

--- a/src/tls_relation.py
+++ b/src/tls_relation.py
@@ -196,5 +196,7 @@ class TLSRelationService:
             typing.Optional[ProviderCertificate]: ProviderCertificate if exists, else None.
         """
         provider_certificates = self.certificates.get_provider_certificates()
-        matching_certs = [cert for cert in provider_certificates if cert == certificate]
+        matching_certs = [
+            cert for cert in provider_certificates if cert.certificate == certificate
+        ]
         return matching_certs[0] if matching_certs else None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,6 +6,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from charms.tls_certificates_interface.v3.tls_certificates import TLSCertificatesRequiresV3
 from lightkube.core.client import Client
 from lightkube.generic_resource import GenericGlobalResource
 from lightkube.models.meta_v1 import ObjectMeta
@@ -61,9 +62,9 @@ def gateway_class_resource_fixture():
 
 
 @pytest.fixture(scope="function", name="private_key_and_password")
-def private_key_and_password_fixture() -> tuple[str, str]:
+def private_key_and_password_fixture(harness: Harness) -> tuple[str, str]:
     """Mock private key juju secret."""
-    tls = TLSRelationService(MagicMock())
+    tls = TLSRelationService(harness.model, MagicMock(spec=TLSCertificatesRequiresV3))
     password = tls.generate_password().encode()
     private_key = generate_private_key(password=password)
     return (password.decode(), private_key.decode())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,18 +61,18 @@ def gateway_class_resource_fixture():
 
 
 @pytest.fixture(scope="function", name="private_key_and_password")
-def private_key_and_password_fixture(harness: Harness) -> tuple[str, str]:
+def private_key_and_password_fixture() -> tuple[str, str]:
     """Mock private key juju secret."""
-    tls = TLSRelationService(harness.model)
+    tls = TLSRelationService(MagicMock())
     password = tls.generate_password().encode()
     private_key = generate_private_key(password=password)
     return (password.decode(), private_key.decode())
 
 
 @pytest.fixture(scope="function", name="mock_certificate")
-def mock_certificate_fixture() -> str:
+def mock_certificate_fixture(monkeypatch: pytest.MonkeyPatch) -> str:
     """Mock tls certificate from a tls provider charm."""
-    return (
+    cert = (
         "-----BEGIN CERTIFICATE-----"
         "MIIDgDCCAmigAwIBAgIUa32Vp4pS2WjrTNG7SZJ66SdMs2YwDQYJKoZIhvcNAQEL"
         "BQAwOTELMAkGA1UEBhMCVVMxKjAoBgNVBAMMIXNlbGYtc2lnbmVkLWNlcnRpZmlj"
@@ -95,3 +95,13 @@ def mock_certificate_fixture() -> str:
         "4+3+0/6Ba2Zlt9fu4PixG+XukQnBIxtIMjWp7q7xWp8F4aOW"
         "-----END CERTIFICATE-----"
     )
+    provider_cert_mock = MagicMock()
+    provider_cert_mock.certificate = cert
+    monkeypatch.setattr(
+        (
+            "charms.tls_certificates_interface.v3.tls_certificates"
+            ".TLSCertificatesRequiresV3.get_provider_certificates"
+        ),
+        MagicMock(return_value=[provider_cert_mock]),
+    )
+    return cert

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,7 +6,6 @@
 from unittest.mock import MagicMock
 
 import pytest
-from charms.tls_certificates_interface.v3.tls_certificates import TLSCertificatesRequiresV3
 from lightkube.core.client import Client
 from lightkube.generic_resource import GenericGlobalResource
 from lightkube.models.meta_v1 import ObjectMeta
@@ -64,7 +63,7 @@ def gateway_class_resource_fixture():
 @pytest.fixture(scope="function", name="private_key_and_password")
 def private_key_and_password_fixture(harness: Harness) -> tuple[str, str]:
     """Mock private key juju secret."""
-    tls = TLSRelationService(harness.model, MagicMock(spec=TLSCertificatesRequiresV3))
+    tls = TLSRelationService(harness.model, MagicMock())
     password = tls.generate_password().encode()
     private_key = generate_private_key(password=password)
     return (password.decode(), private_key.decode())

--- a/tests/unit/test_certificates_integration.py
+++ b/tests/unit/test_certificates_integration.py
@@ -3,17 +3,10 @@
 
 """Unit tests for certificates integration."""
 
-from typing import Dict
-from unittest.mock import MagicMock, PropertyMock
-
-import ops
 import pytest
 from ops.testing import Harness
 
 import tls_relation
-from state.config import CharmConfig
-
-from .conftest import GATEWAY_CLASS_CONFIG, TEST_EXTERNAL_HOSTNAME_CONFIG
 
 
 @pytest.mark.usefixtures("patch_lightkube_client")
@@ -25,47 +18,8 @@ def test_generate_password(harness: Harness):
     """
     harness.begin()
 
-    tls_rel = tls_relation.TLSRelationService(harness.charm.model)
+    tls_rel = tls_relation.TLSRelationService(harness.charm.certificates)
 
     password = tls_rel.generate_password()
     assert isinstance(password, str)
     assert len(password) == 12
-
-
-@pytest.mark.usefixtures("patch_lightkube_client")
-def test_cert_relation(
-    harness: Harness,
-    certificates_relation_data: Dict[str, str],
-    monkeypatch: pytest.MonkeyPatch,
-):
-    """
-    arrange: Given a charm with mocked tls module methods and valid config.
-    act: when relation with a TLS provider is established.
-    assert: the charm correctly generates a password and a CSR.
-    """
-    generate_password_mock = MagicMock(return_value="123456789101")
-    monkeypatch.setattr(
-        tls_relation.TLSRelationService, "generate_password", generate_password_mock
-    )
-    monkeypatch.setattr(
-        tls_relation.TLSRelationService, "update_relation_data_fields", MagicMock()
-    )
-    generate_csr_mock = MagicMock(return_value=b"csr")
-    monkeypatch.setattr(tls_relation, "generate_csr", generate_csr_mock)
-    has_secrets_mock = PropertyMock(return_value=True)
-    monkeypatch.setattr(ops.JujuVersion, "has_secrets", has_secrets_mock)
-    get_secret_mock = MagicMock()
-    monkeypatch.setattr(ops.model.Model, "get_secret", get_secret_mock)
-    monkeypatch.setattr(
-        "state.config.CharmConfig.from_charm", MagicMock(return_value=MagicMock(spec=CharmConfig))
-    )
-    harness.update_config(
-        {"external-hostname": TEST_EXTERNAL_HOSTNAME_CONFIG, "gateway-class": GATEWAY_CLASS_CONFIG}
-    )
-    harness.begin()
-    harness.add_relation(
-        "certificates", "self-signed-certificates", app_data=certificates_relation_data
-    )
-    generate_password_mock.assert_called_once()
-    generate_csr_mock.assert_called_once()
-    assert get_secret_mock.call_count == 2

--- a/tests/unit/test_certificates_integration.py
+++ b/tests/unit/test_certificates_integration.py
@@ -18,7 +18,7 @@ def test_generate_password(harness: Harness):
     """
     harness.begin()
 
-    tls_rel = tls_relation.TLSRelationService(harness.charm.certificates)
+    tls_rel = tls_relation.TLSRelationService(harness.model, harness.charm.certificates)
 
     password = tls_rel.generate_password()
     assert isinstance(password, str)


### PR DESCRIPTION
Follow up to comments on #28 and internal discussions. The `tls_relation` module needs to be simplified and the `certificates` integration handling logic needs to be improved.

This PR refactors and tries to simplify the `tls_relation` module, the `tls_information` charm state component and the `SecretResourceDefinition` used to manage k8s secrets:

* `tls_relation` module is now initialized with the certificates requirer v3 lib, replacing all direct modification of the integration data with library calls. Remove useless code that stores the certificates information on the application's integration data.
* `TLSInformation` state component now no longer stores the tls integration integration.
* `SecretResourceDefinition` now is built directly from TLSInformation using `SecretResourceDefinition.from_tls_information` class method
* Simplify the `certificates` integration handling logic.
* Update tests to accomodate the above changes

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
