### PR TITLE
fix: rustc toolchain

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -15,8 +15,11 @@ parts:
       - pkg-config
       - libffi-dev
       - libssl-dev
-      - rustc
-      - cargo
+    build-snaps:
+      - rustup
+    override-build: |
+      rustup default stable
+      craftctl default
 
 name: gateway-api-integrator
 title: Gateway API Integrator


### PR DESCRIPTION
Applicable spec: <link>

### Overview

- Fixes outdated rustc toolchain
<!-- A high level overview of the change -->

### Rationale

- We had to pin `rpdy-py` which renovates complains about which [fails when udpated](https://github.com/canonical/gateway-api-integrator-operator/actions/runs/10053094014/job/27785342726?pr=53#step:4:1464).
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
