### PR TITLE
rername test

### DIFF
--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -10,7 +10,7 @@ from .conftest import TEST_EXTERNAL_HOSTNAME_CONFIG
 
 
 @pytest.mark.abort_on_fail
-async def test_deploy(
+async def test_get_certificate_action(
     configured_application_with_tls: Application,
 ):
     """Deploy the charm with valid config and tls integration.


### PR DESCRIPTION
This PR renames the integration test in `test_action.py` to `test_get_certificate_action` to be more explicit about what the test does.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
