### PR TITLE
update service and http route name to avoid collision

### DIFF
--- a/src/resource_manager/http_route.py
+++ b/src/resource_manager/http_route.py
@@ -154,7 +154,7 @@ class HTTPRouteResourceManager(ResourceManager[GenericNamespacedResource]):
             kind=HTTP_ROUTE_RESOURCE_NAME,
             metadata=ObjectMeta(
                 name=(
-                    f"{http_route_resource_definition.service_name}"
+                    f"{http_route_resource_definition.gateway_name}"
                     f"-{http_route_resource_definition.http_route_type}"
                 ),
                 labels=self._labels,
@@ -261,7 +261,7 @@ class HTTPRouteRedirectResourceManager(HTTPRouteResourceManager):
             kind=HTTP_ROUTE_RESOURCE_NAME,
             metadata=ObjectMeta(
                 name=(
-                    f"{http_route_resource_definition.service_name}"
+                    f"{http_route_resource_definition.gateway_name}"
                     f"-{http_route_resource_definition.http_route_type}"
                 ),
                 labels=self._labels,

--- a/src/state/http_route.py
+++ b/src/state/http_route.py
@@ -64,7 +64,7 @@ class HTTPRouteResourceInformation:
             integration_data = ingress_provider.get_data(ingress_integration)
             application_name = integration_data.app.name
             requirer_model_name = integration_data.app.model
-            service_name = f"{application_name}-gateway-service"
+            service_name = f"{charm.app.name}-{application_name}-service"
             service_port = integration_data.app.port
             service_port_name = f"tcp-{service_port}"
 


### PR DESCRIPTION
From Weii's comment : https://github.com/canonical/gateway-api-integrator-operator/pull/33#discussion_r1686707071. This PR renames the created service resource to include `charm.app.name` to avoid collision with services created by other charms / manually created services in the same k8s namespace.

This PR also changes the name of the created http_route resource to include `gateway_name` instead of `service_name`

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
