### PR TITLE
Fix reference to wrong charm in docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Gateway API is an open-source project that welcomes community contributions, sug
 * [Read our Code of Conduct](https://ubuntu.com/community/code-of-conduct)
 * [Join the Discourse forum](https://discourse.charmhub.io/tag/synapse)
 * [Discuss on the Matrix chat service](https://chat.charmhub.io/charmhub/channels/charm-dev)
-* Contribute and report bugs to [the Synapse operator](https://github.com/canonical/gateway-api-integrator-operator)
+* Contribute and report bugs to [the Gateway API integrator operator](https://github.com/canonical/gateway-api-integrator-operator)
 * Check the [release notes](https://github.com/canonical/gateway-api-integrator-operator/releases)
 
 ## Contributing to this documentation


### PR DESCRIPTION
Applicable spec: N/A

### Overview

Trivial doc update.

### Rationale

Refer to the correct charm.

### Juju Events Changes

N/A

### Module Changes

N/A

### Library Changes

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation is generated using `src-docs`
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
