### PR TITLE
Add support for strip_prefix

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -428,6 +428,7 @@ class GatewayAPICharm(CharmBase):
                 http_route_resource_information,
                 gateway_resource_information,
                 HTTPRouteType.HTTP,
+                http_route_resource_information.strip_prefix,
             )
         )
         https_route = http_route_resource_manager.define_resource(

--- a/src/charm.py
+++ b/src/charm.py
@@ -435,6 +435,7 @@ class GatewayAPICharm(CharmBase):
                 http_route_resource_information,
                 gateway_resource_information,
                 HTTPRouteType.HTTPS,
+                http_route_resource_information.strip_prefix,
             )
         )
         service_resource_manager.cleanup_resources(exclude=[service])

--- a/src/resource_manager/http_route.py
+++ b/src/resource_manager/http_route.py
@@ -144,17 +144,21 @@ class HTTPRouteResourceManager(ResourceManager[GenericNamespacedResource]):
                             }
                         }
                     ],
-                    "filters": [] if not http_route_resource_definition.strip_prefix else [
-                        {
-                            "type": "URLRewrite",
-                            "urlRewrite": {
-                                "path": {
-                                    "type": "ReplacePrefixMatch",
-                                    "replacePrefixMatch": "/"
-                                }
+                    "filters": (
+                        []
+                        if not http_route_resource_definition.strip_prefix
+                        else [
+                            {
+                                "type": "URLRewrite",
+                                "urlRewrite": {
+                                    "path": {
+                                        "type": "ReplacePrefixMatch",
+                                        "replacePrefixMatch": "/",
+                                    }
+                                },
                             }
-                        }
-                    ],
+                        ]
+                    ),
                     "backendRefs": [
                         {
                             "name": http_route_resource_definition.service_name,

--- a/src/state/http_route.py
+++ b/src/state/http_route.py
@@ -31,6 +31,7 @@ class HTTPRouteResourceInformation:
         service_name: The name of the service we're creating.
         service_port: The port of the service.
         service_port_name: The port name of the service.
+        strip_prefix: Whether to strip the generated prefix.
     """
 
     application_name: str
@@ -38,6 +39,7 @@ class HTTPRouteResourceInformation:
     service_name: str
     service_port: int
     service_port_name: str
+    strip_prefix: bool
 
     @classmethod
     def from_charm(
@@ -67,6 +69,7 @@ class HTTPRouteResourceInformation:
             service_name = f"{charm.app.name}-{application_name}-service"
             service_port = integration_data.app.port
             service_port_name = f"tcp-{service_port}"
+            strip_prefix = integration_data.app.strip_prefix
 
             return cls(
                 application_name=application_name,
@@ -74,6 +77,7 @@ class HTTPRouteResourceInformation:
                 service_name=service_name,
                 service_port=service_port,
                 service_port_name=service_port_name,
+                strip_prefix=strip_prefix,
             )
         except DataValidationError as exc:
             raise IngressIntegrationDataValidationError(

--- a/src/state/validation.py
+++ b/src/state/validation.py
@@ -12,8 +12,8 @@ from ops.model import SecretNotFoundError
 
 from resource_manager.resource_manager import InvalidResourceError
 from state.exception import CharmStateValidationBaseError
-from tls_relation import InvalidCertificateError
 from state.http_route import IngressIntegrationMissingError
+from tls_relation import InvalidCertificateError
 
 logger = logging.getLogger(__name__)
 

--- a/src/state/validation.py
+++ b/src/state/validation.py
@@ -13,6 +13,7 @@ from ops.model import SecretNotFoundError
 from resource_manager.resource_manager import InvalidResourceError
 from state.exception import CharmStateValidationBaseError
 from tls_relation import InvalidCertificateError
+from state.http_route import IngressIntegrationMissingError
 
 logger = logging.getLogger(__name__)
 
@@ -63,12 +64,12 @@ def validate_config_and_integration(
             """
             try:
                 return method(instance, *args)
-            except CharmStateValidationBaseError as exc:
+            except (CharmStateValidationBaseError, IngressIntegrationMissingError) as exc:
                 if defer:
                     event: ops.EventBase
                     event, *_ = args
                     event.defer()
-                logger.exception("Error setting up charm state.")
+                logger.exception("Error setting up charm state component: %s", str(exc))
                 instance.unit.status = ops.BlockedStatus(str(exc))
                 return None
             except InvalidResourceError:

--- a/tests/unit/test_http_route.py
+++ b/tests/unit/test_http_route.py
@@ -85,18 +85,24 @@ def test_httproute_gen_resource(
         labels=harness.charm._labels,
         client=client_mock,
     )
-    redirect_route_resource = redirect_route_resource_manager._gen_resource(
-        HTTPRouteResourceDefinition(
-            http_route_resource_information,
-            gateway_resource_information,
-            HTTPRouteType.HTTP,
+    redirect_route_resource = (
+        redirect_route_resource_manager._gen_resource(  # pylint: disable=duplicate-code
+            HTTPRouteResourceDefinition(
+                http_route_resource_information,
+                gateway_resource_information,
+                HTTPRouteType.HTTP,
+                http_route_resource_information.strip_prefix,
+            )
         )
     )
-    https_route_resource = http_route_resource_manager._gen_resource(
-        HTTPRouteResourceDefinition(
-            http_route_resource_information,
-            gateway_resource_information,
-            HTTPRouteType.HTTPS,
+    https_route_resource = (
+        http_route_resource_manager._gen_resource(  # pylint: disable=duplicate-code
+            HTTPRouteResourceDefinition(
+                http_route_resource_information,
+                gateway_resource_information,
+                HTTPRouteType.HTTPS,
+                http_route_resource_information.strip_prefix,
+            )
         )
     )
     assert (

--- a/tests/unit/test_http_route.py
+++ b/tests/unit/test_http_route.py
@@ -2,7 +2,8 @@
 # See LICENSE file for licensing details.
 
 # Disable protected access rules to test charm._labels and charm._ingress_provider
-# pylint: disable=protected-access
+# Disable duplicate-code as we're initializing the http-route resource the same way as in charm.py
+# pylint: disable=protected-access,duplicate-code
 """Unit tests for http_route resource."""
 from unittest.mock import MagicMock
 
@@ -85,24 +86,20 @@ def test_httproute_gen_resource(
         labels=harness.charm._labels,
         client=client_mock,
     )
-    redirect_route_resource = (
-        redirect_route_resource_manager._gen_resource(  # pylint: disable=duplicate-code
-            HTTPRouteResourceDefinition(
-                http_route_resource_information,
-                gateway_resource_information,
-                HTTPRouteType.HTTP,
-                http_route_resource_information.strip_prefix,
-            )
+    redirect_route_resource = redirect_route_resource_manager._gen_resource(
+        HTTPRouteResourceDefinition(
+            http_route_resource_information,
+            gateway_resource_information,
+            HTTPRouteType.HTTP,
+            http_route_resource_information.strip_prefix,
         )
     )
-    https_route_resource = (
-        http_route_resource_manager._gen_resource(  # pylint: disable=duplicate-code
-            HTTPRouteResourceDefinition(
-                http_route_resource_information,
-                gateway_resource_information,
-                HTTPRouteType.HTTPS,
-                http_route_resource_information.strip_prefix,
-            )
+    https_route_resource = http_route_resource_manager._gen_resource(
+        HTTPRouteResourceDefinition(
+            http_route_resource_information,
+            gateway_resource_information,
+            HTTPRouteType.HTTPS,
+            http_route_resource_information.strip_prefix,
         )
     )
     assert (


### PR DESCRIPTION
Add support for strip_prefix, adding a rewrite rule to the generated httproute resource.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
