### PR TITLE
Re-check Vale and fix errors

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,1 @@
+HTTPRoute

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# gateway-api-integrator-operator
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# Gateway API integrator operator
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 [![CharmHub Badge](https://charmhub.io/gateway-api-integrator/badge.svg)](https://charmhub.io/gateway-api-integrator)
 [![Publish to edge](https://github.com/canonical/gateway-api-integrator-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/gateway-api-integrator-operator/actions/workflows/publish_charm.yaml)

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,4 +1,6 @@
-# Tutorial: Deploy the Gateway API integrator charm
+<!-- vale Canonical.007-Headings-sentence-case = NO -->
+# Deploy the Gateway API integrator charm
+<!-- vale Canonical.007-Headings-sentence-case = YES -->
 
 ## What you'll do
 This tutorial will walk you through deploying the gateway-api-integrator charm; you will:
@@ -6,8 +8,8 @@ This tutorial will walk you through deploying the gateway-api-integrator charm; 
 2. Establish an integration with a TLS provider charm
 
 ## Prerequisites
-* A kubernetes cluster with a gateway controller installed.
-* A host machine with juju version 3.3 or above.
+* A Kubernetes cluster with a gateway controller installed.
+* A host machine with Juju version 3.3 or above.
 
 ## Deploy and configure the gateway-api-integrator charm
 1. Deploy and configure the charm


### PR DESCRIPTION
Applicable ticket: ISD-3949

### Overview

Run Vale checks locally and fix errors.

### Rationale

There's a bug in operator-workflows that points to an older version of the Canonical Vale style checks. Therefore some of the checks will be missed in the GitHub CI.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Either discourse-gatekeeper will update the documentation on Charmhub or I'll do it after the approval of this PR. 
