### PR TITLE
Promote the correct base

### DIFF
--- a/.github/workflows/promote_gateway_api_integrator_charm.yaml
+++ b/.github/workflows/promote_gateway_api_integrator_charm.yaml
@@ -13,12 +13,6 @@ on:
         description: 'Destination Channel'
         options:
         - latest/stable
-      base-channel:
-        type: choice
-        description: 'Base Channel'
-        options:
-        - 24.04
-        - 22.04
     secrets:
       CHARMHUB_TOKEN:
         required: true
@@ -29,7 +23,7 @@ jobs:
     with:
       origin-channel: ${{ github.event.inputs.origin-channel }}
       destination-channel: ${{ github.event.inputs.destination-channel }}
-      base-channel: ${{ github.event.inputs.base-channel }}
       doc-automation-disabled: false
       working-directory: ./gateway-api-integrator
+      base-channel: 24.04
     secrets: inherit


### PR DESCRIPTION
Applicable spec: <link>

### Overview

It was promoting the old base 22.04 but we are not using that anymore, the promote action must promote the 24.04 base to stable.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [ ] The `CHANGELOG.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
