### PR TITLE
Use merge patch strategy when updating gateway

### DIFF
--- a/gateway-api-integrator/src/resource_manager/gateway.py
+++ b/gateway-api-integrator/src/resource_manager/gateway.py
@@ -168,14 +168,14 @@ class GatewayResourceManager(ResourceManager[GenericNamespacedResource]):
             name: The name of the resource to patch.
             resource: The modified gateway resource object.
         """
-        # Patch the resource with server-side apply
+        # Patch the resource with merge to correctly handle tls-certificates relation removal.
         # force=True is required here so that the charm keeps control of the resource
         self._client.patch(  # type: ignore[type-var]
             # mypy can't detect that this is ok for patching custom resources
             self._gateway_generic_resource,
             name,
             resource,
-            patch_type=PatchType.APPLY,
+            patch_type=PatchType.MERGE,
             force=True,
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,4 +11,5 @@ def pytest_addoption(parser):
         parser: Pytest parser.
     """
     parser.addoption("--charm-file", action="append")
+    parser.addoption("--gateway-class", action="store")
     parser.addoption("--kube-config", action="store", default="~/.kube/config")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,9 +24,10 @@ class App(NamedTuple):
 
 
 @pytest.fixture(scope="module", name="gateway_class")
-def gateway_class_fixture():
+def gateway_class_fixture(pytestconfig: pytest.Config):
     """Fixture to provide the gateway class for the charm."""
-    yield "cilium"
+    gateway_class = pytestconfig.getoption("--gateway-class")
+    yield gateway_class or "cilium"  # default to cilium if not set
 
 
 @pytest.fixture(scope="module", name="external_hostname")


### PR DESCRIPTION
This is so that the second listener is properly removed when tls-certificates relation is removed. If the second listener is not removed ( in case of server-side apply ), the charm will go into an error state because the k8s api will reply with 422 Unprocessable Entity

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)
- [x] The `CHANGELOG.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
