### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -77,8 +77,9 @@ def gateway_api_integrator(
         config={
             "gateway-class": gateway_class,
         },
+        log=False,
     )
-    juju.deploy("self-signed-certificates")
+    juju.deploy("self-signed-certificates", log=False)
     juju.integrate(
         "gateway-api-integrator",
         "self-signed-certificates",
@@ -102,6 +103,7 @@ def gateway_route_configurator(
         base="ubuntu@24.04",
         trust=True,
         config={"hostname": external_hostname, "paths": "/app1,/app2"},
+        log=False,
     )
 
     return App("gateway-route-configurator")
@@ -124,6 +126,7 @@ def gateway_api_integrator_no_tls(
             "gateway-class": gateway_class,
             "enforce-https": False,
         },
+        log=False,
     )
     return application
 
@@ -134,9 +137,5 @@ def gateway_route_backend_application(
 ) -> str:
     """Deploy the gateway-api-integrator charm and necessary charms for it."""
     application = "flask"
-    juju.deploy(
-        "flask-k8s",
-        application,
-        channel="latest/edge",
-    )
+    juju.deploy("flask-k8s", application, channel="latest/edge", log=False)
     return application

--- a/tests/e2e/test_configurator.py
+++ b/tests/e2e/test_configurator.py
@@ -70,12 +70,10 @@ def test_configurator(
     juju.config(
         gateway_route_configurator.name,
         {"additional-hostnames": ",".join(additional_hostnames)},
+        log=False,
     )
 
-    juju.deploy(
-        "flask-k8s",
-        channel="latest/edge",
-    )
+    juju.deploy("flask-k8s", channel="latest/edge", log=False)
 
     juju.integrate(
         f"{gateway_route_configurator.name}:ingress",
@@ -107,7 +105,7 @@ def test_configurator(
     assert get_url_from_relation(juju, "flask-k8s/0") == f"https://{external_hostname}/app1"
 
     # HTTP with hostname
-    juju.config(gateway_api_integrator.name, {"enforce-https": False})
+    juju.config(gateway_api_integrator.name, {"enforce-https": False}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(
             status, gateway_route_configurator.name, "flask-k8s", gateway_api_integrator.name
@@ -123,7 +121,6 @@ def test_configurator(
             headers={"Host": additional_hostname},
         )
         assert response.status_code == 200, (
-            f"Failed to route to {additional_hostname}: "
-            f"status={response.status_code}"
+            f"Failed to route to {additional_hostname}: " f"status={response.status_code}"
         )
         assert "Welcome to flask-k8s Charm" in response.text

--- a/tests/e2e/test_http.py
+++ b/tests/e2e/test_http.py
@@ -90,7 +90,7 @@ def test_http(
     assert response.status_code == 200
     assert "Welcome to flask-k8s Charm" in response.text
 
-    juju.config(gateway_route_configurator.name, reset="hostname")
+    juju.config(gateway_route_configurator.name, reset="hostname", log=False)
     juju.wait(
         lambda status: jubilant.all_active(
             status,


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.