### PR TITLE
chore(ci): add actions:read and contents:write permissions to publish workflows (charmkeeper)

### DIFF
--- a/.github/workflows/publish_gateway_api_integrator_charm.yaml
+++ b/.github/workflows/publish_gateway_api_integrator_charm.yaml
@@ -4,13 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'gateway-api-integrator/**'
+    - 'gateway-api-integrator/**'
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      actions: read
+      contents: write
     secrets: inherit
     with:
       working-directory: "./gateway-api-integrator"

--- a/.github/workflows/publish_gateway_route_configurator_charm.yaml
+++ b/.github/workflows/publish_gateway_route_configurator_charm.yaml
@@ -4,13 +4,16 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+    - main
     paths:
-      - 'gateway-route-configurator/**'
+    - 'gateway-route-configurator/**'
 
 jobs:
   publish-to-edge:
     uses: canonical/operator-workflows/.github/workflows/publish_charm.yaml@main
+    permissions:
+      actions: read
+      contents: write
     secrets: inherit
     with:
       working-directory: "./gateway-route-configurator"


### PR DESCRIPTION
This PR adds `actions: read` and `contents: write` permissions to GitHub Actions jobs that use the `canonical/operator-workflows/.github/workflows/publish_charm.yaml` reusable workflow or `canonical/charming-actions/upload-charm` action.
These permissions are required for the workflow to function correctly with the latest changes to the reusable workflow.