### PR TITLE
fix: set SNI in requests in e2e tests to ensure matching hostname with multiple listeners

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ dev = [
 integration = [
     "allure-pytest>=2.8.18",
     "allure-pytest-collection-report @ git+https://github.com/canonical/data-platform-workflows@v24.0.0#subdirectory=python/pytest_plugins/allure_pytest_collection_report",
+    "httpx>=0.28.1",
     "jubilant==1.10.0",
     "pytest",
     "pytest-asyncio",

--- a/tests/e2e/helper.py
+++ b/tests/e2e/helper.py
@@ -4,15 +4,83 @@
 """Shared helpers for e2e tests."""
 
 import ipaddress
+from urllib.parse import urlparse
 
 import jubilant
 import requests
 import urllib3
+from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, HTTPAdapter
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
 from urllib3.exceptions import InsecureRequestWarning
 
 # Disable SSL warnings when using verify=False
 urllib3.disable_warnings(InsecureRequestWarning)
+
+
+class DNSResolverAdapter(HTTPAdapter):
+    """A simple mounted DNS resolver for HTTP requests, with retry support."""
+
+    def __init__(
+        self,
+        hostname,
+        ip,
+    ):
+        """Initialize the DNS resolver with retry configuration.
+
+        Args:
+            hostname: DNS entry to resolve.
+            ip: Target IP address.
+        """
+        self.hostname = hostname
+        self.ip = ip
+
+        super().__init__(
+            max_retries=DEFAULT_RETRIES,
+            pool_connections=DEFAULT_POOLSIZE,
+            pool_maxsize=DEFAULT_POOLSIZE,
+            pool_block=DEFAULT_POOLBLOCK,
+        )
+
+    # Ignore pylint rule as this is the parent method signature
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):  # pylint: disable=too-many-arguments, too-many-positional-arguments
+        """Wrap HTTPAdapter send to modify the outbound request.
+
+        Args:
+            request: Outbound HTTP request.
+            stream: argument used by parent method.
+            timeout: argument used by parent method.
+            verify: argument used by parent method.
+            cert: argument used by parent method.
+            proxies: argument used by parent method.
+
+        Returns:
+            Response: HTTP response after modification.
+        """
+        connection_pool_kwargs = self.poolmanager.connection_pool_kw
+
+        result = urlparse(request.url)
+        if result.hostname == self.hostname:
+            ip = self.ip
+            if result.scheme == "http" and ip:
+                request.url = request.url.replace(
+                    "http://" + result.hostname,
+                    "http://" + ip,
+                )
+                connection_pool_kwargs["server_hostname"] = result.hostname
+                request.headers["Host"] = result.hostname
+            elif result.scheme == "https" and ip:
+                request.url = request.url.replace(
+                    "https://" + result.hostname,
+                    "https://" + ip,
+                )
+                connection_pool_kwargs["server_hostname"] = result.hostname
+                connection_pool_kwargs["assert_hostname"] = result.hostname
+                request.headers["Host"] = result.hostname
+            else:
+                connection_pool_kwargs.pop("server_hostname", None)
+                connection_pool_kwargs.pop("assert_hostname", None)
+
+        return super().send(request, stream, timeout, verify, cert, proxies)
 
 
 @retry(
@@ -32,12 +100,19 @@ def assert_gateway_route_response(
     allow_redirects: bool = True,
 ) -> requests.Response:
     """Get a gateway route and assert expected response, retrying while dataplane converges."""
-    headers = {"Host": hostname} if hostname is not None else None
-    response = requests.get(
-        f"{scheme}://{gateway_address}{path}",
+    session = requests.Session()
+    if hostname is not None:
+        # Resolve the hostname to the gateway IP so the Host header and TLS SNI carry it,
+        # which hostname-scoped gateway listeners require to route correctly.
+        session.mount(f"{scheme}://{hostname}", DNSResolverAdapter(hostname, gateway_address))
+        url = f"{scheme}://{hostname}{path}"
+    else:
+        url = f"{scheme}://{gateway_address}{path}"
+
+    response = session.get(
+        url,
         verify=False,
         timeout=10,
-        headers=headers,
         allow_redirects=allow_redirects,
     )
 

--- a/tests/e2e/helper.py
+++ b/tests/e2e/helper.py
@@ -4,89 +4,16 @@
 """Shared helpers for e2e tests."""
 
 import ipaddress
-from urllib.parse import urlparse
 
+import httpx
 import jubilant
-import requests
-import urllib3
-from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, HTTPAdapter
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_fixed
-from urllib3.exceptions import InsecureRequestWarning
-
-# Disable SSL warnings when using verify=False
-urllib3.disable_warnings(InsecureRequestWarning)
-
-
-class DNSResolverAdapter(HTTPAdapter):
-    """A simple mounted DNS resolver for HTTP requests, with retry support."""
-
-    def __init__(
-        self,
-        hostname,
-        ip,
-    ):
-        """Initialize the DNS resolver with retry configuration.
-
-        Args:
-            hostname: DNS entry to resolve.
-            ip: Target IP address.
-        """
-        self.hostname = hostname
-        self.ip = ip
-
-        super().__init__(
-            max_retries=DEFAULT_RETRIES,
-            pool_connections=DEFAULT_POOLSIZE,
-            pool_maxsize=DEFAULT_POOLSIZE,
-            pool_block=DEFAULT_POOLBLOCK,
-        )
-
-    # Ignore pylint rule as this is the parent method signature
-    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):  # pylint: disable=too-many-arguments, too-many-positional-arguments
-        """Wrap HTTPAdapter send to modify the outbound request.
-
-        Args:
-            request: Outbound HTTP request.
-            stream: argument used by parent method.
-            timeout: argument used by parent method.
-            verify: argument used by parent method.
-            cert: argument used by parent method.
-            proxies: argument used by parent method.
-
-        Returns:
-            Response: HTTP response after modification.
-        """
-        connection_pool_kwargs = self.poolmanager.connection_pool_kw
-
-        result = urlparse(request.url)
-        if result.hostname == self.hostname:
-            ip = self.ip
-            if result.scheme == "http" and ip:
-                request.url = request.url.replace(
-                    "http://" + result.hostname,
-                    "http://" + ip,
-                )
-                connection_pool_kwargs["server_hostname"] = result.hostname
-                request.headers["Host"] = result.hostname
-            elif result.scheme == "https" and ip:
-                request.url = request.url.replace(
-                    "https://" + result.hostname,
-                    "https://" + ip,
-                )
-                connection_pool_kwargs["server_hostname"] = result.hostname
-                connection_pool_kwargs["assert_hostname"] = result.hostname
-                request.headers["Host"] = result.hostname
-            else:
-                connection_pool_kwargs.pop("server_hostname", None)
-                connection_pool_kwargs.pop("assert_hostname", None)
-
-        return super().send(request, stream, timeout, verify, cert, proxies)
 
 
 @retry(
     stop=stop_after_delay(180),
     wait=wait_fixed(5),
-    retry=retry_if_exception_type((AssertionError, requests.exceptions.RequestException)),
+    retry=retry_if_exception_type((AssertionError, httpx.RequestError)),
     reraise=True,
 )
 def assert_gateway_route_response(
@@ -98,23 +25,27 @@ def assert_gateway_route_response(
     expected_status: int = 200,
     body_contains: str | None = None,
     allow_redirects: bool = True,
-) -> requests.Response:
+) -> httpx.Response:
     """Get a gateway route and assert expected response, retrying while dataplane converges."""
-    session = requests.Session()
     if hostname is not None:
-        # Resolve the hostname to the gateway IP so the Host header and TLS SNI carry it,
+        # Connect to the gateway IP while sending the hostname as Host header and TLS SNI,
         # which hostname-scoped gateway listeners require to route correctly.
-        session.mount(f"{scheme}://{hostname}", DNSResolverAdapter(hostname, gateway_address))
         url = f"{scheme}://{hostname}{path}"
+        extensions = {"sni_hostname": hostname.encode()}
+        headers = {"Host": hostname}
+        transport = httpx.HTTPTransport(verify=False)
+        with httpx.Client(transport=transport) as client:
+            response = client.get(
+                url,
+                headers=headers,
+                extensions=extensions,
+                follow_redirects=allow_redirects,
+                timeout=10,
+            )
     else:
         url = f"{scheme}://{gateway_address}{path}"
-
-    response = session.get(
-        url,
-        verify=False,
-        timeout=10,
-        allow_redirects=allow_redirects,
-    )
+        with httpx.Client(verify=False) as client:
+            response = client.get(url, follow_redirects=allow_redirects, timeout=10)
 
     assert response.status_code == expected_status, (
         f"Failed to route to {hostname}: status={response.status_code}, "

--- a/tests/e2e/helper.py
+++ b/tests/e2e/helper.py
@@ -27,7 +27,7 @@ def assert_gateway_route_response(
     allow_redirects: bool = True,
 ) -> httpx.Response:
     """Get a gateway route and assert expected response, retrying while dataplane converges."""
-    url = f"{scheme}://{hostname if hostname else gateway_address}{path}"
+    url = f"{scheme}://{gateway_address}{path}"
     # When a hostname is given, send it as Host header and TLS SNI so that
     # hostname-scoped gateway listeners route the request correctly.
     extensions = {"sni_hostname": hostname.encode()} if hostname else {}
@@ -39,12 +39,12 @@ def assert_gateway_route_response(
         )
 
     assert response.status_code == expected_status, (
-        f"Failed to route to {hostname}: status={response.status_code}, "
+        f"Failed to route to {hostname if hostname else gateway_address}: status={response.status_code}, "
         f"expected={expected_status}, body={response.text!r}"
     )
     if body_contains is not None:
         assert body_contains in response.text, (
-            f"Expected response body for {hostname} to contain {body_contains!r}, "
+            f"Expected response body for {hostname if hostname else gateway_address} to contain {body_contains!r}, "
             f"body={response.text!r}"
         )
 

--- a/tests/e2e/helper.py
+++ b/tests/e2e/helper.py
@@ -27,25 +27,16 @@ def assert_gateway_route_response(
     allow_redirects: bool = True,
 ) -> httpx.Response:
     """Get a gateway route and assert expected response, retrying while dataplane converges."""
-    if hostname is not None:
-        # Connect to the gateway IP while sending the hostname as Host header and TLS SNI,
-        # which hostname-scoped gateway listeners require to route correctly.
-        url = f"{scheme}://{hostname}{path}"
-        extensions = {"sni_hostname": hostname.encode()}
-        headers = {"Host": hostname}
-        transport = httpx.HTTPTransport(verify=False)
-        with httpx.Client(transport=transport) as client:
-            response = client.get(
-                url,
-                headers=headers,
-                extensions=extensions,
-                follow_redirects=allow_redirects,
-                timeout=10,
-            )
-    else:
-        url = f"{scheme}://{gateway_address}{path}"
-        with httpx.Client(verify=False) as client:
-            response = client.get(url, follow_redirects=allow_redirects, timeout=10)
+    url = f"{scheme}://{hostname if hostname else gateway_address}{path}"
+    # When a hostname is given, send it as Host header and TLS SNI so that
+    # hostname-scoped gateway listeners route the request correctly.
+    extensions = {"sni_hostname": hostname.encode()} if hostname else {}
+    headers = {"Host": hostname} if hostname else {}
+    with httpx.Client(verify=False) as client:
+        response = client.send(
+            httpx.Request("GET", url, headers=headers, extensions=extensions),
+            follow_redirects=allow_redirects,
+        )
 
     assert response.status_code == expected_status, (
         f"Failed to route to {hostname}: status={response.status_code}, "

--- a/tests/e2e/ingress_requirer.py
+++ b/tests/e2e/ingress_requirer.py
@@ -6,9 +6,9 @@
 import pathlib
 import subprocess
 
-from charmlibs import apt
 import ops
 from any_charm_base import AnyCharmBase
+from charmlibs import apt
 from ingress import IngressPerAppRequirer
 
 

--- a/tests/e2e/test_configurator.py
+++ b/tests/e2e/test_configurator.py
@@ -6,6 +6,7 @@
 import jubilant
 import pytest
 import requests
+
 from .helper import (
     assert_gateway_route_response,
     get_gateway_ip,

--- a/uv.lock
+++ b/uv.lock
@@ -410,6 +410,7 @@ dev = [
 integration = [
     { name = "allure-pytest" },
     { name = "allure-pytest-collection-report" },
+    { name = "httpx" },
     { name = "jubilant" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -438,6 +439,7 @@ dev = [
 integration = [
     { name = "allure-pytest", specifier = ">=2.8.18" },
     { name = "allure-pytest-collection-report", git = "https://github.com/canonical/data-platform-workflows?subdirectory=python%2Fpytest_plugins%2Fallure_pytest_collection_report&rev=v24.0.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "jubilant", specifier = "==1.10.0" },
     { name = "pytest" },
     { name = "pytest-asyncio" },


### PR DESCRIPTION

#### What this PR does

Switch to using httpx for requiests which allows setting an SNI.
When a hostname is provided, assert_gateway_route_response builds the URL from the hostname (ensuring SNI is set correctly) and mounts the adapter to route the TCP connection to the gateway IP.

#### Why we need it
The multiple-listeners change (rev 163) switched the Gateway resource from a single hostname-less HTTPS listener to per-hostname HTTPS listeners, each with an explicit [hostname](vscode-file://vscode-app/snap/code/247/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field. Cilium enforces SNI matching against the listener hostname during the TLS handshake.

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [x] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [x] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

