### PR TITLE
fix: add tag-prefix to promote workflow

### DIFF
--- a/.github/workflows/promote_gateway_api_integrator_charm.yaml
+++ b/.github/workflows/promote_gateway_api_integrator_charm.yaml
@@ -28,4 +28,5 @@ jobs:
       doc-automation-disabled: false
       working-directory: ./gateway-api-integrator
       base-channel: 24.04
+      tag-prefix: gateway-api-integrator
     secrets: inherit


### PR DESCRIPTION
#### What this PR does

#### Why we need it

After the promotion and publishing of the charm, the workflow searched for a tag with the format `rev{N}`, when it should be `gateway-api-integrator-rev{N}` which is remediated by passing a `tag-prefix`

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

