### PR TITLE
fix(docs): Update sitemap configuration

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Each revision is versioned by the date of the revision.
 
+## 2026-07-13
+
+- Fixed the sitemap configuration for the RTD project.
+
 ## 2026-07-06
 
 - Removed the source code for the `gateway-route-configurator` charm that is replaced by the `ingress-configurator-charm`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,6 +191,8 @@ html_baseurl = f"https://canonical.com/juju/docs/gateway-api-integrator-charm/{v
 
 sitemap_url_scheme = '{link}'
 
+sitemap_filename = "doc-sitemap.xml"
+
 # Include `lastmod` dates in the sitemap:
 
 sitemap_show_lastmod = True


### PR DESCRIPTION
#### What this PR does

Adds `sitemap_filename` to `docs/conf.py`.

#### Why we need it

The current sitemap for the RTD project is mega broken: 
<img width="1054" height="980" alt="image" src="https://github.com/user-attachments/assets/b2efb99b-7908-4778-b640-f624f9609403" />

The sitemap URLs should match the domain, but they don't. The RTD-hosted URL should be overwritten with the Canonical domain, but it isn't. I'm not sure why this is the only project that's affected. 

This PR aligns the project with the recommendations for sitemap configuration (which were updated after the URL migration was completed). To verify, view the sitemap for the RTD preview of this PR: https://canonical-gateway-api-integrator-juju-charm--293.com.readthedocs.build/293/doc-sitemap.xml

#### Checklist

- [X] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [X] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [N/A] I used AI to assist with preparing this PR
- [N/A] I added or updated tests as needed (unit and integration)
- [N/A] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [N/A] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

