### PR TITLE
chore: add error to jubilant.wait

### DIFF
--- a/gateway-api-integrator/tests/integration/conftest.py
+++ b/gateway-api-integrator/tests/integration/conftest.py
@@ -19,6 +19,7 @@ CERTIFICATE_PROVIDER_CHANNEL = "1/edge"
 INGRESS_REQUIRER_CHANNEL = "latest/edge"
 TEST_EXTERNAL_HOSTNAME_CONFIG = "gateway.internal"
 GATEWAY_CLASS_CONFIG = "ck-gateway"
+JUJU_WAIT_TIMEOUT = 10 * 60
 
 
 @pytest.fixture(scope="module", name="juju")
@@ -26,7 +27,7 @@ def juju_model_fixture(request: pytest.FixtureRequest):
     """Create a temporary Juju model for testing."""
     keep_models = bool(request.config.getoption("--keep-models"))
     with jubilant.temp_model(keep=keep_models) as juju_model:
-        juju_model.wait_timeout = 10 * 60
+        juju_model.wait_timeout = JUJU_WAIT_TIMEOUT
         yield juju_model
 
         if request.session.testsfailed:
@@ -44,7 +45,10 @@ def charm_fixture(charm_paths) -> str:
 def application_fixture(juju: jubilant.Juju, charm: str) -> str:
     """Deploy the charm and wait for blocked status."""
     juju.deploy(charm, app=GATEWAY_APP_NAME, base=GATEWAY_BASE, trust=True)
-    juju.wait(lambda status: status.apps[GATEWAY_APP_NAME].app_status.current == "blocked")
+    juju.wait(
+        lambda status: status.apps[GATEWAY_APP_NAME].app_status.current == "blocked",
+        error=jubilant.any_error,
+    )
     return GATEWAY_APP_NAME
 
 
@@ -52,7 +56,10 @@ def application_fixture(juju: jubilant.Juju, charm: str) -> str:
 def certificate_provider_application_fixture(juju: jubilant.Juju) -> str:
     """Deploy self-signed-certificates."""
     juju.deploy(CERTIFICATE_PROVIDER_APP_NAME, channel=CERTIFICATE_PROVIDER_CHANNEL)
-    juju.wait(lambda status: jubilant.all_active(status, CERTIFICATE_PROVIDER_APP_NAME))
+    juju.wait(
+        lambda status: jubilant.all_active(status, CERTIFICATE_PROVIDER_APP_NAME),
+        error=jubilant.any_error,
+    )
     return CERTIFICATE_PROVIDER_APP_NAME
 
 
@@ -98,6 +105,6 @@ def configured_application_with_tls_fixture(
     juju.integrate(application, certificate_provider_application)
     juju.wait(
         lambda status: jubilant.all_active(status, application, certificate_provider_application),
-        timeout=600,
+        error=jubilant.any_error,
     )
     return application

--- a/gateway-api-integrator/tests/integration/test_actions.py
+++ b/gateway-api-integrator/tests/integration/test_actions.py
@@ -26,7 +26,7 @@ def test_get_certificate_action(
         lambda status: jubilant.all_active(
             status, configured_application_with_tls, ingress_requirer_application
         ),
-        timeout=600,
+        error=jubilant.any_error,
     )
 
     result = juju.run(

--- a/gateway-api-integrator/tests/integration/test_charm_dns.py
+++ b/gateway-api-integrator/tests/integration/test_charm_dns.py
@@ -27,7 +27,7 @@ def test_dns_record_relation(
     juju.integrate(gateway_app, f"{ingress_requirer_application}:ingress")
     juju.wait(
         lambda status: jubilant.all_active(status, gateway_app, ingress_requirer_application),
-        timeout=600,
+        error=jubilant.any_error,
     )
 
     # Deploy any-charm that provides the dns-record relation
@@ -36,7 +36,7 @@ def test_dns_record_relation(
         channel="latest/beta",
     )
     juju.integrate(f"{gateway_app}:dns-record", "any-charm")
-    juju.wait(jubilant.all_active)
+    juju.wait(jubilant.all_active, error=jubilant.any_error)
 
     # Assert that the dns-record is in the relation data
     if juju.version().major >= 4:
@@ -57,7 +57,7 @@ def test_dns_record_relation(
             break
 
     juju.remove_relation(gateway_app, INGRESS_REQUIRER_APP_NAME)
-    juju.wait(lambda status: jubilant.all_active(status, gateway_app))
+    juju.wait(lambda status: jubilant.all_active(status, gateway_app), error=jubilant.any_error)
     model_name = juju.show_model().short_name
     cmd = (
         f"kubectl -n {model_name} get all,httproute,service "

--- a/gateway-api-integrator/tests/integration/test_charm_ingress_interface.py
+++ b/gateway-api-integrator/tests/integration/test_charm_ingress_interface.py
@@ -37,7 +37,7 @@ def test_ingress_enforced_mode(
     juju.wait(
         lambda status: jubilant.all_active(status, ingress_requirer_application, application),
         delay=5,
-        timeout=600,
+        error=jubilant.any_error,
     )
 
     gateway = get_gateway_resource(lightkube_client, application)
@@ -95,7 +95,7 @@ def test_ingress_enabled_mode(
     juju.wait(
         lambda status: jubilant.all_active(status, application, ingress_requirer_application),
         delay=5,
-        timeout=600,
+        error=jubilant.any_error,
     )
 
     gateway = get_gateway_resource(lightkube_client, application)
@@ -147,7 +147,7 @@ def test_ingress_disabled_mode(
     juju.wait(
         lambda status: jubilant.all_active(status, application, ingress_requirer_application),
         delay=5,
-        timeout=600,
+        error=jubilant.any_error,
     )
 
     gateway = get_gateway_resource(lightkube_client, application)


### PR DESCRIPTION
#### What this PR does
adds error arg to juju.wait to fail fast instead of waiting for the timeout if any charm is in error state

removed the explicit passing of timeout to juju.wait which is the same as the globally assigned one

#### Why we need it

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

