### PR TITLE
chore: update publish workflow to trigger on charm code changes

### DIFF
--- a/.github/workflows/publish_gateway_api_integrator_charm.yaml
+++ b/.github/workflows/publish_gateway_api_integrator_charm.yaml
@@ -10,7 +10,7 @@ on:
     - 'gateway-api-integrator/lib/**'
     - 'gateway-api-integrator/charmcraft.yaml'
     - 'gateway-api-integrator/pyproject.toml'
-    - 'gateway-api-integrator/uv.lock'
+    - 'gateway-api-integrator/uv.lock' 
 
 jobs:
   publish-to-edge:

--- a/.github/workflows/publish_gateway_api_integrator_charm.yaml
+++ b/.github/workflows/publish_gateway_api_integrator_charm.yaml
@@ -6,7 +6,11 @@ on:
     branches:
     - main
     paths:
-    - 'gateway-api-integrator/**'
+    - 'gateway-api-integrator/src/**'
+    - 'gateway-api-integrator/lib/**'
+    - 'gateway-api-integrator/charmcraft.yaml'
+    - 'gateway-api-integrator/pyproject.toml'
+    - 'gateway-api-integrator/uv.lock'
 
 jobs:
   publish-to-edge:


### PR DESCRIPTION
#### What this PR does

Changes the publish charm to only publish a charm revision when the code changes modify the actual charm that would be packed.

#### Why we need it

Reduces the number of the released revisions when the changes are for documentation, or tests.

#### Checklist

- [ ] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [ ] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

