### PR TITLE
feat: add hsts heading to responses

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -2,3 +2,4 @@ HTTPRoute
 configurator
 workloadless
 hostnames
+databag

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,10 @@ Each revision is versioned by the date of the revision.
 - Added the `hsts-max-age` configuration option to control the `max-age` directive of the `Strict-Transport-Security` header injected on HTTPS routes when HTTPS is enforced.
 - Added the `hsts_max_age` field to the `gateway-route` provider databag (library v1, LIBPATCH 3), published only when HTTPS is enforced.
 
+## 2026-07-13
+
+- Fixed the sitemap configuration for the RTD project.
+
 ## 2026-07-06
 
 - Removed the source code for the `gateway-route-configurator` charm that is replaced by the `ingress-configurator-charm`.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Each revision is versioned by the date of the revision.
 
-## 2026-07-13
+## 2026-07-20
 
-- Fixed the sitemap configuration for the RTD project.
+- Added the `hsts-max-age` configuration option to control the `max-age` directive of the `Strict-Transport-Security` header injected on HTTPS routes when HTTPS is enforced.
+- Added the `hsts_max_age` field to the `gateway-route` provider databag (library v1, LIBPATCH 3), published only when HTTPS is enforced.
 
 ## 2026-07-06
 

--- a/gateway-api-integrator/README.md
+++ b/gateway-api-integrator/README.md
@@ -46,6 +46,18 @@ juju deploy self-signed-certificates
 juju integrate gateway-api-integrator self-signed-certificates
 ```
 
+#### Configure HSTS
+
+When HTTPS is enforced (`enforce-https=true`), the charm injects a
+`Strict-Transport-Security` header on HTTPS routes. The `hsts-max-age`
+configuration sets the `max-age` directive (in seconds) of that header. It
+defaults to `31536000` (1 year) and is only applied when HTTPS is enforced.
+Setting it to `0` instructs browsers to clear any cached HSTS policy.
+
+```
+juju config gateway-api-integrator hsts-max-age=63072000
+```
+
 ## Learn more
 
 - [Read more](https://canonical.com/juju/docs/gateway-api-integrator-charm/)

--- a/gateway-api-integrator/charmcraft.yaml
+++ b/gateway-api-integrator/charmcraft.yaml
@@ -63,6 +63,13 @@ config:
         When set to false, plain HTTP traffic on port 80 is allowed and the HTTPS listener is not created.
         Setting this to false also makes the external-hostname configuration optional.
       type: boolean
+    hsts-max-age:
+      default: 31536000
+      description: |
+        Value for the max-age directive of the Strict-Transport-Security header injected on HTTPS routes.
+        Only applied when HTTPS is enforced. The default is 31536000 (1 year).
+        Setting this to 0 instructs browsers to clear any cached HSTS policy.
+      type: int
 
 
 actions:

--- a/gateway-api-integrator/lib/charms/gateway_api_integrator/v1/gateway_route.py
+++ b/gateway-api-integrator/lib/charms/gateway_api_integrator/v1/gateway_route.py
@@ -119,7 +119,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 GATEWAY_ROUTE_RELATION_NAME = "gateway-route"
@@ -193,6 +193,8 @@ class GatewayRouteProviderAppData:
         https_mode: The HTTPS mode indicating how the provider handles TLS.
         gateway_address: The gateway LB address. Provided so requirers without a
             configured hostname can reference the gateway by IP.
+        hsts_max_age: The max-age value for the Strict-Transport-Security header.
+            Set only when HTTPS is enforced; None otherwise.
     """
 
     gateway_name: str = Field(description="The name of the Gateway resource.")
@@ -202,6 +204,10 @@ class GatewayRouteProviderAppData:
     https_mode: HttpsMode = Field(description="The HTTPS mode: disabled, enabled, or enforced.")
     gateway_address: str | None = Field(
         description="The gateway LB address, used when no hostname is configured.",
+        default=None,
+    )
+    hsts_max_age: int | None = Field(
+        description="The max-age for the Strict-Transport-Security header, set only when enforced.",
         default=None,
     )
 
@@ -263,6 +269,7 @@ class GatewayRouteProvider(Object):
         gateway_model: str,
         https_mode: HttpsMode,
         gateway_address: str | None = None,
+        hsts_max_age: int | None = None,
     ) -> None:
         """Publish gateway information to requirers with valid data.
 
@@ -273,6 +280,8 @@ class GatewayRouteProvider(Object):
             gateway_model: The Juju model (K8s namespace) of the Gateway resource.
             https_mode: The HTTPS mode for the gateway.
             gateway_address: The gateway LB address, used when no hostname is configured.
+            hsts_max_age: The max-age for the Strict-Transport-Security header. Should
+                only be set when HTTPS is enforced; None otherwise.
 
         Raises:
             GatewayRouteInvalidRelationDataError: When publishing fails for any relation.
@@ -288,6 +297,7 @@ class GatewayRouteProvider(Object):
                     gateway_model=gateway_model,
                     https_mode=https_mode,
                     gateway_address=gateway_address,
+                    hsts_max_age=hsts_max_age,
                 )
                 relation.save(app_data, self.charm.app)
             except (ValidationError, RelationDataTypeError):

--- a/gateway-api-integrator/lib/charms/gateway_api_integrator/v1/gateway_route.py
+++ b/gateway-api-integrator/lib/charms/gateway_api_integrator/v1/gateway_route.py
@@ -209,6 +209,7 @@ class GatewayRouteProviderAppData:
     hsts_max_age: int | None = Field(
         description="The max-age for the Strict-Transport-Security header, set only when enforced.",
         default=None,
+        ge=0,
     )
 
 

--- a/gateway-api-integrator/src/charm.py
+++ b/gateway-api-integrator/src/charm.py
@@ -419,7 +419,9 @@ class GatewayAPICharm(CharmBase):
             gateway_model=self.model.name,
             https_mode=https_mode,
             gateway_address=gateway_address,
-            hsts_max_age=(charm_state.hsts_max_age if https_mode == HttpsMode.ENFORCED else None),
+            hsts_max_age=(
+                charm_state.hsts_max_age if https_mode == HttpsMode.ENFORCED else None
+            ),
         )
 
     def _update_dns_record_relation(

--- a/gateway-api-integrator/src/charm.py
+++ b/gateway-api-integrator/src/charm.py
@@ -419,9 +419,7 @@ class GatewayAPICharm(CharmBase):
             gateway_model=self.model.name,
             https_mode=https_mode,
             gateway_address=gateway_address,
-            hsts_max_age=(
-                charm_state.hsts_max_age if https_mode == HttpsMode.ENFORCED else None
-            ),
+            hsts_max_age=(charm_state.hsts_max_age if https_mode == HttpsMode.ENFORCED else None),
         )
 
     def _update_dns_record_relation(

--- a/gateway-api-integrator/src/charm.py
+++ b/gateway-api-integrator/src/charm.py
@@ -419,6 +419,7 @@ class GatewayAPICharm(CharmBase):
             gateway_model=self.model.name,
             https_mode=https_mode,
             gateway_address=gateway_address,
+            hsts_max_age=(charm_state.hsts_max_age if https_mode == HttpsMode.ENFORCED else None),
         )
 
     def _update_dns_record_relation(
@@ -568,6 +569,7 @@ class GatewayAPICharm(CharmBase):
                     http_route_resource_information,
                     gateway_resource_information,
                     HTTPRouteType.HTTPS,
+                    hsts_max_age=charm_state.hsts_max_age,
                 ),
             ]
         else:

--- a/gateway-api-integrator/src/resource_manager/http_route.py
+++ b/gateway-api-integrator/src/resource_manager/http_route.py
@@ -59,6 +59,8 @@ class HTTPRouteResourceDefinition(ResourceDefinition):
         paths: The list of paths to be added to the HTTPRoute resource.
         filters: The list of filters to be applied to the HTTPRoute resource.
         matches: The list of matches for the HTTPRoute resource.
+        hsts_max_age: The max-age for the Strict-Transport-Security header. When set on
+            an HTTPS route, a ResponseHeaderModifier filter is injected; None disables it.
     """
 
     application_name: str
@@ -71,6 +73,7 @@ class HTTPRouteResourceDefinition(ResourceDefinition):
     paths: list[str]
     filters: list[dict]
     hostname: str | None
+    hsts_max_age: int | None
 
     def __init__(
         self,
@@ -78,6 +81,7 @@ class HTTPRouteResourceDefinition(ResourceDefinition):
         gateway_resource_information: GatewayResourceInformation,
         http_route_type: HTTPRouteType,
         redirect_https: bool = False,
+        hsts_max_age: int | None = None,
     ):
         """Create the state object with state components.
 
@@ -86,10 +90,13 @@ class HTTPRouteResourceDefinition(ResourceDefinition):
             gateway_resource_information: GatewayResourceInformation state component.
             http_route_type: Type of the HTTP route, can be http or https.
             redirect_https: Whether to redirect HTTP traffic to HTTPS.
+            hsts_max_age: The max-age for the Strict-Transport-Security header. Set only
+                when HTTPS is enforced; None otherwise.
         """
         super().__init__(http_route_resource_information, gateway_resource_information)
         self.http_route_type = http_route_type
         self.redirect_https = redirect_https
+        self.hsts_max_age = hsts_max_age
 
     @property
     def matches(self) -> list[dict[str, dict[str, str]]]:
@@ -154,6 +161,30 @@ class HTTPRouteResourceDefinition(ResourceDefinition):
         """
         return [] if self.hostname is None else [self.hostname]
 
+    @property
+    def _hsts_filter(self) -> dict | None:
+        """Build the Strict-Transport-Security ResponseHeaderModifier filter.
+
+        The filter is only produced for HTTPS routes when hsts_max_age is set. A value of
+        0 is still emitted so browsers clear any cached HSTS policy.
+
+        Returns:
+            The HSTS ResponseHeaderModifier filter, or None when it does not apply.
+        """
+        if self.http_route_type != HTTPRouteType.HTTPS or self.hsts_max_age is None:
+            return None
+        return {
+            "type": "ResponseHeaderModifier",
+            "responseHeaderModifier": {
+                "add": [
+                    {
+                        "name": "Strict-Transport-Security",
+                        "value": f"max-age={self.hsts_max_age}",
+                    }
+                ]
+            },
+        }
+
     def http_route_resource_spec(self, namespace: str) -> dict[str, typing.Any]:
         """Generate a Gateway resource from a gateway resource definition.
 
@@ -196,7 +227,10 @@ class HTTPRouteResourceDefinition(ResourceDefinition):
             "rules": [
                 {
                     "matches": self.matches,
-                    "filters": self.filters,
+                    "filters": [
+                        *self.filters,
+                        *filter(None, [self._hsts_filter]),
+                    ],
                     "backendRefs": [
                         {
                             "name": self.service_name,

--- a/gateway-api-integrator/src/state/charm_state.py
+++ b/gateway-api-integrator/src/state/charm_state.py
@@ -67,6 +67,8 @@ class CharmState:
     Attributes:
         gateway_class_name: The configured gateway class.
         enforce_https: Whether to enforce HTTPS by redirecting HTTP to HTTPS.
+        hsts_max_age: The max-age value for the Strict-Transport-Security header,
+            injected on HTTPS routes only when HTTPS is enforced.
         proxy_mode: Current proxy mode selected from active relations.
         requires_ip_certificate: Whether an IP SAN certificate is required. This
             is true only when certificates are integrated, proxy mode is
@@ -79,6 +81,7 @@ class CharmState:
     enforce_https: bool = Field()
     proxy_mode: ProxyMode = Field()
     requires_ip_certificate: bool = Field()
+    hsts_max_age: int = Field(ge=0)
     hostnames: set[
         typing.Annotated[
             str,
@@ -122,6 +125,7 @@ class CharmState:
             CharmState: Instance of the charm state component.
         """
         enforce_https = typing.cast(bool, charm.config.get("enforce-https", True))
+        hsts_max_age = typing.cast(int, charm.config.get("hsts-max-age"))
         has_tls = charm.model.get_relation(TLS_CERTIFICATES_INTEGRATION) is not None
         if enforce_https and not has_tls:
             raise InvalidCharmConfigError(
@@ -173,6 +177,7 @@ class CharmState:
             return CharmState(
                 gateway_class_name=gateway_class_name,
                 enforce_https=enforce_https,
+                hsts_max_age=hsts_max_age,
                 proxy_mode=proxy_mode,
                 requires_ip_certificate=requires_ip_certificate,
                 hostnames=hostnames,

--- a/gateway-api-integrator/tests/unit/test_certificates_integration.py
+++ b/gateway-api-integrator/tests/unit/test_certificates_integration.py
@@ -28,6 +28,7 @@ def test_tls_information_integration_missing() -> None:
             enforce_https=True,
             proxy_mode=ProxyMode.INGRESS,
             requires_ip_certificate=False,
+            hsts_max_age=31536000,
             hostnames={"example.com"},
         )
         with pytest.raises(TlsIntegrationMissingError):

--- a/gateway-api-integrator/tests/unit/test_charm.py
+++ b/gateway-api-integrator/tests/unit/test_charm.py
@@ -166,6 +166,7 @@ def test_get_certificate_requests_includes_gateway_ip_when_required(
                 enforce_https=True,
                 proxy_mode=ProxyMode.GATEWAY_ROUTE,
                 requires_ip_certificate=True,
+                hsts_max_age=31536000,
                 hostnames=set(),
             )
         ),
@@ -245,6 +246,7 @@ def test_waiting_when_ip_san_certificate_missing(
                 enforce_https=True,
                 proxy_mode=ProxyMode.INGRESS,
                 requires_ip_certificate=True,
+                hsts_max_age=31536000,
                 hostnames={"example.com"},
             )
         ),

--- a/gateway-api-integrator/tests/unit/test_charm_state.py
+++ b/gateway-api-integrator/tests/unit/test_charm_state.py
@@ -23,6 +23,7 @@ def test_valid_ingress_config():
         enforce_https=True,
         proxy_mode=ProxyMode.INGRESS,
         requires_ip_certificate=False,
+        hsts_max_age=31536000,
         hostnames={"gateway.internal"},
     )
     assert charm_state.hostnames == {"gateway.internal"}
@@ -42,6 +43,7 @@ def test_valid_ingress_config_no_hostnames():
         enforce_https=False,
         proxy_mode=ProxyMode.INGRESS,
         requires_ip_certificate=False,
+        hsts_max_age=31536000,
         hostnames=set(),
     )
     assert charm_state.hostnames == set()
@@ -59,6 +61,7 @@ def test_valid_gateway_route_config_enforce_https_false():
         enforce_https=False,
         proxy_mode=ProxyMode.GATEWAY_ROUTE,
         requires_ip_certificate=False,
+        hsts_max_age=31536000,
         hostnames={"example.com"},
     )
     assert charm_state.hostnames == {"example.com"}
@@ -72,6 +75,7 @@ def test_valid_inactive_config():
         enforce_https=False,
         proxy_mode=ProxyMode.INACTIVE,
         requires_ip_certificate=False,
+        hsts_max_age=31536000,
         hostnames=set(),
     )
     assert type(charm_state) is CharmState
@@ -89,6 +93,7 @@ def test_invalid_gateway_class_name_empty():
             enforce_https=True,
             proxy_mode=ProxyMode.INGRESS,
             requires_ip_certificate=False,
+            hsts_max_age=31536000,
             hostnames={"gateway.internal"},
         )
 
@@ -105,6 +110,7 @@ def test_invalid_ingress_hostname():
             enforce_https=True,
             proxy_mode=ProxyMode.INGRESS,
             requires_ip_certificate=False,
+            hsts_max_age=31536000,
             hostnames={"not a valid hostname!"},
         )
 
@@ -117,6 +123,7 @@ def test_invalid_gateway_route_hostname():
             enforce_https=True,
             proxy_mode=ProxyMode.GATEWAY_ROUTE,
             requires_ip_certificate=False,
+            hsts_max_age=31536000,
             hostnames={"not a valid hostname!"},
         )
 
@@ -129,6 +136,7 @@ def test_invalid_ingress_multiple_hostnames():
             enforce_https=True,
             proxy_mode=ProxyMode.INGRESS,
             requires_ip_certificate=False,
+            hsts_max_age=31536000,
             hostnames={"one.example.com", "two.example.com"},
         )
 
@@ -152,6 +160,7 @@ def test_valid_hostnames(hostname: str):
         enforce_https=True,
         proxy_mode=ProxyMode.INGRESS,
         requires_ip_certificate=False,
+        hsts_max_age=31536000,
         hostnames={hostname},
     )
     assert charm_state.hostnames == {hostname}

--- a/gateway-api-integrator/tests/unit/test_gateway_route_v1.py
+++ b/gateway-api-integrator/tests/unit/test_gateway_route_v1.py
@@ -216,6 +216,53 @@ class TestGatewayRouteProvider:
             assert json.loads(app_data["https_mode"]) == "enforced"
             assert json.loads(app_data["gateway_address"]) == "10.0.0.1"
 
+    def test_publish_provider_data_includes_hsts_when_enforced(self, ctx):
+        """Test publish_provider_data writes hsts_max_age when provided (enforced mode)."""
+        relation = testing.Relation(
+            endpoint=GATEWAY_ROUTE_RELATION_NAME,
+            interface="gateway-route",
+            remote_app_data={
+                "hostname": json.dumps("app.example.com"),
+                "additional_hostnames": json.dumps([]),
+            },
+        )
+        state = testing.State(leader=True, relations=[relation])
+
+        with ctx(ctx.on.relation_changed(relation), state) as mgr:
+            mgr.charm.gateway_route.get_requirer_data()
+            mgr.charm.gateway_route.publish_provider_data(
+                gateway_name="my-gateway",
+                gateway_model="my-model",
+                https_mode=HttpsMode.ENFORCED,
+                hsts_max_age=31536000,
+            )
+            rel = mgr.charm.model.get_relation(GATEWAY_ROUTE_RELATION_NAME)
+            app_data = rel.data[mgr.charm.app]
+            assert json.loads(app_data["hsts_max_age"]) == 31536000
+
+    def test_publish_provider_data_omits_hsts_when_not_enforced(self, ctx):
+        """Test publish_provider_data leaves hsts_max_age null when None (not enforced)."""
+        relation = testing.Relation(
+            endpoint=GATEWAY_ROUTE_RELATION_NAME,
+            interface="gateway-route",
+            remote_app_data={
+                "hostname": json.dumps("app.example.com"),
+                "additional_hostnames": json.dumps([]),
+            },
+        )
+        state = testing.State(leader=True, relations=[relation])
+
+        with ctx(ctx.on.relation_changed(relation), state) as mgr:
+            mgr.charm.gateway_route.get_requirer_data()
+            mgr.charm.gateway_route.publish_provider_data(
+                gateway_name="my-gateway",
+                gateway_model="my-model",
+                https_mode=HttpsMode.ENABLED,
+            )
+            rel = mgr.charm.model.get_relation(GATEWAY_ROUTE_RELATION_NAME)
+            app_data = rel.data[mgr.charm.app]
+            assert json.loads(app_data["hsts_max_age"]) is None
+
     def test_publish_provider_data_skips_non_leader(self, ctx):
         """Test publish_provider_data does nothing when not leader."""
         relation = testing.Relation(

--- a/gateway-api-integrator/tests/unit/test_http_route.py
+++ b/gateway-api-integrator/tests/unit/test_http_route.py
@@ -85,6 +85,120 @@ def test_http_route_gen_resource(gateway_relation: testing.Relation) -> None:
         )
 
 
+def _hsts_filters(spec: dict) -> list[dict]:
+    """Return the ResponseHeaderModifier HSTS filters found in a route spec."""
+    filters = []
+    for rule in spec.get("rules", []):
+        for rule_filter in rule.get("filters", []):
+            if rule_filter.get("type") == "ResponseHeaderModifier":
+                for header in rule_filter["responseHeaderModifier"]["add"]:
+                    if header["name"] == "Strict-Transport-Security":
+                        filters.append(rule_filter)
+    return filters
+
+
+def _build_route_spec(gateway_relation: testing.Relation, **definition_kwargs) -> dict:
+    """Build an HTTPRoute resource spec for the given definition kwargs.
+
+    Requires the ``client_with_mock_external`` fixture to be active.
+    """
+    ctx = testing.Context(GatewayAPICharm)
+    state_in = testing.State(
+        leader=True,
+        config={
+            "external-hostname": TEST_EXTERNAL_HOSTNAME_CONFIG,
+            "gateway-class": GATEWAY_CLASS_CONFIG,
+        },
+        relations=[gateway_relation],
+    )
+
+    with ctx(ctx.on.update_status(), state_in) as manager:
+        charm = manager.charm
+        http_route_resource_information = HTTPRouteResourceInformation.from_ingress(
+            charm._ingress_provider, "gateway.internal"
+        )
+        gateway_resource_information = GatewayResourceInformation.from_charm(charm)
+        definition = HTTPRouteResourceDefinition(
+            http_route_resource_information,
+            gateway_resource_information,
+            **definition_kwargs,
+        )
+        return definition.http_route_resource_spec("test-namespace")
+
+
+@pytest.mark.usefixtures("client_with_mock_external")
+def test_https_route_injects_hsts_filter_when_enforced(
+    gateway_relation: testing.Relation,
+) -> None:
+    """
+    arrange: Given an HTTPS HTTPRouteResourceDefinition with hsts_max_age set.
+    act: Generate the HTTPRoute resource spec.
+    assert: A ResponseHeaderModifier filter adds Strict-Transport-Security: max-age=<value>.
+    """
+    spec = _build_route_spec(
+        gateway_relation,
+        http_route_type=HTTPRouteType.HTTPS,
+        hsts_max_age=31536000,
+    )
+    hsts_filters = _hsts_filters(spec)
+    assert len(hsts_filters) == 1
+    header = hsts_filters[0]["responseHeaderModifier"]["add"][0]
+    assert header == {"name": "Strict-Transport-Security", "value": "max-age=31536000"}
+
+
+@pytest.mark.usefixtures("client_with_mock_external")
+def test_https_route_omits_hsts_filter_when_not_enforced(
+    gateway_relation: testing.Relation,
+) -> None:
+    """
+    arrange: Given an HTTPS HTTPRouteResourceDefinition with hsts_max_age unset (None).
+    act: Generate the HTTPRoute resource spec.
+    assert: No Strict-Transport-Security ResponseHeaderModifier filter is present.
+    """
+    spec = _build_route_spec(
+        gateway_relation,
+        http_route_type=HTTPRouteType.HTTPS,
+    )
+    assert _hsts_filters(spec) == []
+
+
+@pytest.mark.usefixtures("client_with_mock_external")
+def test_https_route_hsts_filter_zero_max_age(
+    gateway_relation: testing.Relation,
+) -> None:
+    """
+    arrange: Given an HTTPS HTTPRouteResourceDefinition with hsts_max_age=0.
+    act: Generate the HTTPRoute resource spec.
+    assert: The header is still emitted as max-age=0 to clear cached HSTS policy.
+    """
+    spec = _build_route_spec(
+        gateway_relation,
+        http_route_type=HTTPRouteType.HTTPS,
+        hsts_max_age=0,
+    )
+    hsts_filters = _hsts_filters(spec)
+    assert len(hsts_filters) == 1
+    header = hsts_filters[0]["responseHeaderModifier"]["add"][0]
+    assert header["value"] == "max-age=0"
+
+
+@pytest.mark.usefixtures("client_with_mock_external")
+def test_http_redirect_route_never_injects_hsts_filter(
+    gateway_relation: testing.Relation,
+) -> None:
+    """
+    arrange: Given an HTTP redirect HTTPRouteResourceDefinition.
+    act: Generate the HTTPRoute resource spec.
+    assert: No Strict-Transport-Security filter is added to the redirect rule.
+    """
+    spec = _build_route_spec(
+        gateway_relation,
+        http_route_type=HTTPRouteType.HTTP,
+        redirect_https=True,
+    )
+    assert _hsts_filters(spec) == []
+
+
 def test_patch_http_route(mock_lightkube_client: MagicMock):
     """
     arrange: Given an HTTPRouteResourceManager with mocked lightkube client.


### PR DESCRIPTION
#### What this PR does

adds a config option `hsts-max-age`.

In the case of direct `ingress` relation, the charm uses it to configure the httpRoute resources to set this header with the specified max-age.

In the case of `gateway-route` relation with an ingress-configurator, the value is propagated to the relation data to be used by the ingress-configurator during the creation of httpRoutes.

#### Why we need it

Recommended as a good security practice

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I used AI to assist with preparing this PR
- [x] I added or updated tests as needed (unit and integration)
- [x] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

