### PR TITLE
fix: reorder blocking guards

### DIFF
--- a/gateway-api-integrator/src/state/charm_state.py
+++ b/gateway-api-integrator/src/state/charm_state.py
@@ -151,13 +151,12 @@ class CharmState:
             )
 
         enforce_https = typing.cast(bool, charm.config.get("enforce-https", True))
-        hsts_max_age = typing.cast(int, charm.config.get("hsts-max-age"))
         has_tls = charm.model.get_relation(TLS_CERTIFICATES_INTEGRATION) is not None
         if enforce_https and not has_tls:
             raise InvalidCharmConfigError(
                 "Certificates relation is required when enforce-https is enabled."
             )
- 
+
         if proxy_mode == ProxyMode.INGRESS and has_tls and not config_external_hostname:
             raise HostnameMissingError(
                 "external-hostname must be set when related to ingress and certificates"
@@ -178,7 +177,7 @@ class CharmState:
             return CharmState(
                 gateway_class_name=gateway_class_name,
                 enforce_https=enforce_https,
-                hsts_max_age=hsts_max_age,
+                hsts_max_age=typing.cast(int, charm.config.get("hsts-max-age")),
                 proxy_mode=proxy_mode,
                 requires_ip_certificate=requires_ip_certificate,
                 hostnames=hostnames,

--- a/gateway-api-integrator/src/state/charm_state.py
+++ b/gateway-api-integrator/src/state/charm_state.py
@@ -124,28 +124,7 @@ class CharmState:
         Returns:
             CharmState: Instance of the charm state component.
         """
-        enforce_https = typing.cast(bool, charm.config.get("enforce-https", True))
-        hsts_max_age = typing.cast(int, charm.config.get("hsts-max-age"))
-        has_tls = charm.model.get_relation(TLS_CERTIFICATES_INTEGRATION) is not None
-        if enforce_https and not has_tls:
-            raise InvalidCharmConfigError(
-                "Certificates relation is needed if enforce-https is enabled."
-            )
-
-        proxy_mode = cls._validate_state(
-            ingress_provider.relations, gateway_route_provider.relations
-        )
         gateway_class_name = typing.cast(str, charm.config.get("gateway-class"))
-        config_external_hostname = cls.get_ingress_hostname(charm)
-
-        # external-hostname is an ingress-mode-only config option. In gateway-route
-        # mode hostnames come from the relation data, so setting it is a misconfiguration.
-        if proxy_mode == ProxyMode.GATEWAY_ROUTE and config_external_hostname:
-            raise InvalidCharmConfigError(
-                "external-hostname must only be set when related via ingress, "
-                "not when integrating via gateway-route."
-            )
-
         if gateway_class_name not in available_gateway_classes:
             available_gateway_classes_str = ",".join(available_gateway_classes)
             logger.error(
@@ -157,9 +136,31 @@ class CharmState:
                 f"Gateway class must be one of: [{available_gateway_classes_str}]"
             )
 
+        proxy_mode = cls._validate_state(
+            ingress_provider.relations, gateway_route_provider.relations
+        )
+
+        config_external_hostname = cls.get_ingress_hostname(charm)
+
+        # external-hostname is an ingress-mode-only config option. In gateway-route
+        # mode hostnames come from the relation data, so setting it is a misconfiguration.
+        if proxy_mode == ProxyMode.GATEWAY_ROUTE and config_external_hostname:
+            raise InvalidCharmConfigError(
+                "external-hostname must only be set when related via ingress, "
+                "not when integrating via gateway-route."
+            )
+
+        enforce_https = typing.cast(bool, charm.config.get("enforce-https", True))
+        hsts_max_age = typing.cast(int, charm.config.get("hsts-max-age"))
+        has_tls = charm.model.get_relation(TLS_CERTIFICATES_INTEGRATION) is not None
+        if enforce_https and not has_tls:
+            raise InvalidCharmConfigError(
+                "Certificates relation is required when enforce-https is enabled."
+            )
+ 
         if proxy_mode == ProxyMode.INGRESS and has_tls and not config_external_hostname:
             raise HostnameMissingError(
-                "external-hostname must be set in when related to ingress and certificates"
+                "external-hostname must be set when related to ingress and certificates"
             )
 
         requires_ip_certificate = cls._requires_ip_certificate(

--- a/gateway-api-integrator/tests/unit/test_charm.py
+++ b/gateway-api-integrator/tests/unit/test_charm.py
@@ -295,7 +295,7 @@ def test_deploy_missing_tls() -> None:
     state_out = ctx.run(ctx.on.config_changed(), state_in)
 
     assert state_out.unit_status == ops.BlockedStatus(
-        "Certificates relation is needed if enforce-https is enabled."
+        "Certificates relation is required when enforce-https is enabled."
     )
 
 


### PR DESCRIPTION
#### What this PR does

Reorders the guards that block the charm during reconcile.

- Prioritizes Blocking because of gateway-class.
- Prioritized conflicted setup over missing config/relation ( `proxy_mode == ProxyMode.GATEWAY_ROUTE and config_external_hostname`  takes precedence over `Certificates relation is required when enforce-https is enabled`)
 
#### Why we need it

Provides the user with the blocker in a more relevant order

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [ ] I updated `docs/changelog.md` with user-relevant changes
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this PR involves Terraform:** `terraform fmt` passes and `tflint` reports no errors

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

